### PR TITLE
feat: add Proxmox VE integration and proxmox-admin skill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,7 +692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -698,7 +704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -917,7 +923,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -939,7 +945,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1027,7 +1033,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1213,13 +1219,27 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1241,7 +1261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1418,6 +1438,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1426,13 +1447,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1628,6 +1652,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +1744,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac-notification-sys"
@@ -1811,7 +1857,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1825,7 +1871,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -1983,7 +2029,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
 ]
 
@@ -1996,7 +2042,7 @@ dependencies = [
  "bytes",
  "delegate",
  "futures",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "tokio",
  "windows 0.58.0",
@@ -2113,7 +2159,7 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "pkcs5",
- "rand_core",
+ "rand_core 0.6.4",
  "spki",
 ]
 
@@ -2239,6 +2285,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,6 +2347,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -2260,8 +2367,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2271,7 +2388,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2281,6 +2408,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2328,6 +2464,44 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
 
 [[package]]
 name = "rfc6979"
@@ -2401,7 +2575,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
  "signature",
  "spki",
@@ -2439,8 +2613,8 @@ dependencies = [
  "p384",
  "p521",
  "poly1305",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "russh-cryptovec",
  "russh-keys",
  "russh-sftp",
@@ -2499,8 +2673,8 @@ dependencies = [
  "pkcs1",
  "pkcs5",
  "pkcs8",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "rsa",
  "russh-cryptovec",
  "russh-util",
@@ -2546,6 +2720,12 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2611,6 +2791,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2923,7 +3104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2971,6 +3152,7 @@ dependencies = [
  "notify-rust",
  "parking_lot",
  "prometheus",
+ "reqwest",
  "rmcp",
  "russh",
  "russh-keys",
@@ -3043,7 +3225,7 @@ dependencies = [
  "p256",
  "p384",
  "p521",
- "rand_core",
+ "rand_core 0.6.4",
  "rsa",
  "sec1",
  "sha2",
@@ -3088,6 +3270,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3223,6 +3408,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3369,6 +3569,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -3671,6 +3889,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ russh = "0.46"
 russh-keys = "0.46"
 russh-sftp = "2.1"
 
+# Proxmox REST API
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+
 # Async runtime
 tokio = { version = "1", features = ["full"] }
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ token_id = "root@pam!spacebot"
 token_secret = "${PVE_TOKEN_SECRET}"
 node = "pve1"
 verify_tls = false
+task_wait_timeout_secs = 600
 
 # SSH hosts
 [ssh.hosts.home]

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ args = ["server", "--config", "~/.spacebot-homelab/config.toml"]
 | Tool | Description | Destructive | Confirmation |
 |------|-------------|:-----------:|:------------:|
 | `proxmox.vm.start` | Start a Proxmox VM or LXC container | No | — |
-| `proxmox.vm.stop` | Gracefully stop a Proxmox VM or LXC container | Yes | Yes |
+| `proxmox.vm.stop` | Force-stop a Proxmox VM or LXC container immediately | Yes | Yes |
 | `proxmox.vm.create` | Create a new Proxmox VM or LXC container | Yes | Yes |
 | `proxmox.vm.clone` | Clone an existing Proxmox VM | No | — |
 | `proxmox.vm.delete` | Permanently delete a Proxmox VM or LXC container | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ token_secret = "${PVE_TOKEN_SECRET}"
 node = "pve1"
 verify_tls = false
 task_wait_timeout_secs = 600
+next_vmid_retry_attempts = 3
+next_vmid_retry_backoff_ms = 250
 
 # SSH hosts
 [ssh.hosts.home]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # spacebot-homelab-mcp
 
-An MCP (Model Context Protocol) server that provides Docker and SSH tools for managing homelab infrastructure via Spacebot.
+An MCP (Model Context Protocol) server that provides Docker, SSH, and Proxmox VE tools for managing homelab infrastructure via Spacebot.
 
 This is a standalone Rust binary that runs as an external process. Spacebot connects to it via the MCP protocol and delegates homelab-related tasks to it.
 
@@ -14,10 +14,12 @@ MCP Protocol (stdio)
 spacebot-homelab-mcp
     ├── Connection Manager
     │   ├── Docker clients (local socket + remote TCP/TLS)
-    │   └── SSH connection pool (multiplexed sessions)
-    ├── Tool implementations (18 tools)
+    │   ├── SSH connection pool (multiplexed sessions)
+    │   └── Proxmox REST API clients (token auth + self-signed TLS support)
+    ├── Tool implementations (32 tools)
     │   ├── docker.container.*  (7 tools)
     │   ├── docker.image.*      (5 tools)
+    │   ├── proxmox.*           (14 tools)
     │   ├── ssh.*               (3 tools)
     │   ├── confirm_operation   (confirmation flow)
     │   └── audit.*             (2 verification tools)
@@ -76,6 +78,14 @@ host = "unix:///var/run/docker.sock"
 [docker.hosts.vps]
 host = "tcp://vps.example.com:2375"
 
+# Proxmox VE hosts
+[proxmox.hosts.pve1]
+url = "https://192.168.1.10:8006"
+token_id = "root@pam!spacebot"
+token_secret = "${PVE_TOKEN_SECRET}"
+node = "pve1"
+verify_tls = false
+
 # SSH hosts
 [ssh.hosts.home]
 host = "192.168.1.1"
@@ -103,18 +113,37 @@ blocked_patterns = ["rm -rf", "dd if=", "mkfs", "> /dev/"]
 "docker.image.*" = { per_minute = 5 }
 "docker.image.delete" = { per_minute = 1 }
 "docker.image.prune" = { per_minute = 1 }
+"proxmox.*" = { per_minute = 15 }
 "ssh.exec" = { per_minute = 10 }
 
 # Confirmation rules for destructive operations
+# NOTE: These rules require a client that supports the two-step MCP
+# `confirm_operation` flow. If your Spacebot build/UI does not surface
+# pending confirmations, leave this section disabled and rely on `dry_run`
+# until your client adds confirmation support.
 [confirm]
 "docker.container.delete" = "always"
 "docker.container.stop" = "always"
 "docker.image.delete" = "always"
 "docker.image.prune" = "always"
+"proxmox.vm.stop" = "always"
+"proxmox.vm.create" = "always"
+"proxmox.vm.delete" = "always"
+"proxmox.vm.snapshot.rollback" = "always"
 "ssh.exec" = { when_pattern = ["rm -rf", "dd if=", "systemctl restart"] }
 ```
 
 ## Usage
+
+### Command overview
+
+The binary has three main subcommands:
+
+| Command | Purpose |
+|---------|---------|
+| `server` | Start the MCP server over stdio for Spacebot |
+| `doctor` | Validate config, check Docker/SSH/Proxmox connectivity, and print a readiness summary |
+| `setup` | Launch the interactive configuration wizard |
 
 ### Start the MCP server
 
@@ -124,6 +153,8 @@ spacebot-homelab-mcp server --config ~/.spacebot-homelab/config.toml
 ```
 
 ### Validate configuration
+
+Use `doctor` before connecting Spacebot or after changing `config.toml`. It validates configuration, checks Docker, SSH, and Proxmox connectivity, and prints a summary of security settings and rate limits.
 
 ```bash
 spacebot-homelab-mcp doctor --config ~/.spacebot-homelab/config.toml
@@ -179,6 +210,35 @@ args = ["server", "--config", "~/.spacebot-homelab/config.toml"]
 | `ssh.upload` | Upload a file via SFTP | Yes | — |
 | `ssh.download` | Download a file via SFTP | No | — |
 
+### Proxmox node and VM inventory tools
+
+| Tool | Description | Destructive | Confirmation |
+|------|-------------|:-----------:|:------------:|
+| `proxmox.node.list` | List Proxmox cluster nodes with CPU, memory, uptime, and version | No | — |
+| `proxmox.node.status` | Get detailed node status (CPU, RAM, storage, kernel, uptime) | No | — |
+| `proxmox.vm.list` | List QEMU VMs and LXC containers on a node | No | — |
+| `proxmox.vm.status` | Get detailed status for a VM or container | No | — |
+
+### Proxmox VM lifecycle tools
+
+| Tool | Description | Destructive | Confirmation |
+|------|-------------|:-----------:|:------------:|
+| `proxmox.vm.start` | Start a Proxmox VM or LXC container | No | — |
+| `proxmox.vm.stop` | Gracefully stop a Proxmox VM or LXC container | Yes | Yes |
+| `proxmox.vm.create` | Create a new Proxmox VM or LXC container | Yes | Yes |
+| `proxmox.vm.clone` | Clone an existing Proxmox VM | No | — |
+| `proxmox.vm.delete` | Permanently delete a Proxmox VM or LXC container | Yes | Yes |
+
+### Proxmox snapshot and infrastructure tools
+
+| Tool | Description | Destructive | Confirmation |
+|------|-------------|:-----------:|:------------:|
+| `proxmox.vm.snapshot.list` | List snapshots for a VM or LXC container | No | — |
+| `proxmox.vm.snapshot.create` | Create a VM or container snapshot | No | — |
+| `proxmox.vm.snapshot.rollback` | Roll back a VM or container to a snapshot | Yes | Yes |
+| `proxmox.storage.list` | List Proxmox storage pools and usage | No | — |
+| `proxmox.network.list` | List Proxmox network interfaces, bridges, VLANs, and bonds | No | — |
+
 ### System tools
 
 | Tool | Description |
@@ -191,14 +251,26 @@ args = ["server", "--config", "~/.spacebot-homelab/config.toml"]
 
 Destructive tools use a two-step confirmation flow:
 
-1. Call the destructive tool (e.g. `docker.container.delete`) — returns `confirmation_required` with a UUID token
+1. Call the destructive tool (e.g. `docker.container.delete` or `proxmox.vm.delete`) — returns `confirmation_required` with a UUID token
 2. Call `confirm_operation` with the token and tool name — executes the operation
 
 Tokens are single-use, tool-specific, and expire after 5 minutes.
 
+### Client compatibility
+
+The `[confirm]` rules above only work when the MCP client can complete the second step by calling `confirm_operation`.
+
+If your Spacebot build or UI does not surface pending MCP confirmations yet, destructive tools protected by `[confirm]` will appear to stall because the user cannot complete the confirmation step.
+
+In that case:
+
+1. Leave the `[confirm]` section disabled for homelab MCP tools.
+2. Use `dry_run=true` before destructive operations.
+3. Re-enable `[confirm]` once your client supports MCP confirmation UX.
+
 ### Dry run support
 
-All destructive tools accept a `dry_run` parameter. Set `dry_run=true` to preview what would happen without executing.
+Mutating Docker tools, mutating Proxmox tools, and `ssh.exec` support `dry_run`. Set `dry_run=true` to preview what would happen without executing.
 
 ## Security
 
@@ -213,7 +285,7 @@ All destructive tools accept a `dry_run` parameter. Set `dry_run=true` to previe
 7. **Audit verification tools** — `audit.verify_operation` and `audit.verify_container_state` let callers confirm operations actually happened
 8. **Audit logging** — Append-only log of all tool invocations, outside the agent data directory
 9. **Env var redaction** — Container inspect redacts environment variable values
-10. **Connection validation** — `doctor` subcommand validates all connections at startup
+10. **Connection validation** — `doctor` validates Docker, SSH, and Proxmox connections
 11. **Graceful degradation** — Individual host connections can fail without disabling other tools
 
 ## Development
@@ -224,8 +296,8 @@ All destructive tools accept a `dry_run` parameter. Set `dry_run=true` to previe
 src/
 ├── main.rs              — CLI entry point (server, doctor, setup subcommands)
 ├── config.rs            — Configuration loading and validation
-├── connection.rs        — Connection manager (Docker clients, SSH pool)
-├── mcp.rs               — MCP tool handler (18 tools registered)
+├── connection.rs        — Connection manager (Docker clients, SSH pool, Proxmox clients)
+├── mcp.rs               — MCP tool handler (32 tools registered)
 ├── audit.rs             — Audit logging
 ├── confirmation.rs      — Two-step confirmation manager
 ├── rate_limit.rs        — Per-tool rate limiting
@@ -237,6 +309,7 @@ src/
     ├── mod.rs           — Output envelope wrapping, truncation
     ├── docker.rs        — Docker container tool implementations
     ├── docker_image.rs  — Docker image tool implementations
+    ├── proxmox.rs       — Proxmox VE tool implementations
     ├── ssh.rs           — SSH tool implementations
     └── verify.rs        — Audit verification tool implementations
 tests/

--- a/SPACEBOT-UI-CONFIRMATION-INTEGRATION.md
+++ b/SPACEBOT-UI-CONFIRMATION-INTEGRATION.md
@@ -1,0 +1,184 @@
+# Spacebot Web UI Confirmation Integration
+
+## Purpose
+
+This note documents the MCP confirmation-flow work that was needed in the main `spacebot` app so destructive `spacebot-homelab-mcp` tools are usable from the Spacebot web UI.
+
+This file is intended for upstream review of `spacebot-homelab-mcp` so it is clear that:
+
+1. The MCP server-side confirmation flow already existed in `spacebot-homelab-mcp`.
+2. The missing piece was client support in the main `spacebot` app.
+3. Older Spacebot builds may need `[confirm]` rules left disabled until their client/UI supports `confirm_operation`.
+
+## Summary
+
+`spacebot-homelab-mcp` destructive tools such as:
+
+- `docker.container.stop`
+- `docker.container.delete`
+- `docker.image.delete`
+- `docker.image.prune`
+- `proxmox.vm.stop`
+- `proxmox.vm.create`
+- `proxmox.vm.delete`
+- `proxmox.vm.snapshot.rollback`
+
+can require confirmation through the MCP tool `confirm_operation`.
+
+The MCP server returns a structured `confirmation_required` response with a token. A compatible client must then call `confirm_operation` with that token and tool name.
+
+Before the Spacebot web UI changes, the user-visible failure mode was:
+
+1. The agent asked for plain-text confirmations like `confirm stop VM 100`.
+2. The UI did not expose the pending confirmation token.
+3. The agent could get stuck in a text-only confirmation loop.
+4. In practice, users often had to disable `[confirm]` rules for destructive homelab commands.
+
+## What Already Existed In `spacebot-homelab-mcp`
+
+The MCP server already had the correct server-side behavior:
+
+- destructive tool handlers call the confirmation manager
+- `confirmation_required` responses include a token
+- `confirm_operation` executes the second step
+- audit logging records the destructive operation lifecycle
+
+No protocol change was needed in the MCP server for the web UI flow itself.
+
+## What Had To Change In `spacebot`
+
+The main Spacebot app needed both backend and frontend work.
+
+### Backend / API
+
+- detect MCP `confirmation_required` tool results
+- store pending confirmations per portal/web chat session
+- expose API endpoints to list pending confirmations
+- expose API endpoints to confirm or dismiss a pending confirmation
+- call the MCP server's `confirm_operation` tool from the backend
+- publish the confirmed result back into the portal conversation transcript
+- emit live events so the web UI updates without refresh
+
+### Frontend / Web UI
+
+- fetch pending confirmations for the active portal conversation
+- render a visible confirmation card in the chat UI
+- provide `Confirm action` and `Dismiss` controls
+- remove the card when resolved
+- show the confirmed result back in the chat transcript
+
+### Prompting / Agent Behavior
+
+The Spacebot channel prompt also needed updates so the agent would:
+
+- stop inventing plain-text confirmation protocols
+- stop saying things like `Stopping it now` without actually calling tools
+- use a worker for MCP-backed infrastructure actions
+- call the destructive MCP tool first, then let the UI handle confirmation
+
+## Files Changed In `spacebot`
+
+### Web UI / API flow
+
+- `src/api/state.rs`
+  - Added pending MCP confirmation storage.
+  - Added parsing of `confirmation_required` tool results.
+  - Added `McpConfirmationPending` and `McpConfirmationResolved` events.
+
+- `src/api/portal.rs`
+  - Added portal endpoints to list, confirm, and dismiss pending confirmations.
+  - Added portal-side publishing of confirmed results back into chat.
+
+- `src/api/server.rs`
+  - Registered the new portal confirmation routes.
+
+- `src/api/system.rs`
+  - Added SSE/event-stream support for the new confirmation events.
+
+- `src/mcp.rs`
+  - Added backend execution path for `confirm_operation` against the correct MCP server.
+  - Added helpers for MCP tool namespacing and tool-result text extraction.
+
+- `src/tools/mcp.rs`
+  - Reused the shared MCP namespacing helper so confirmation routing is stable.
+
+- `interface/src/api/client.ts`
+  - Added frontend API methods and types for pending confirmations.
+
+- `interface/src/api/schema.d.ts`
+  - Regenerated schema/types for the new portal confirmation endpoints.
+
+- `interface/src/components/WebChatPanel.tsx`
+  - Added the visible confirmation card UI.
+  - Added confirm and dismiss actions.
+  - Added live updates for pending/resolved confirmations.
+
+- `interface/src/hooks/useLiveContext.tsx`
+  - Bridged backend confirmation events into browser events for the portal chat UI.
+
+### Prompting / agent behavior
+
+- `prompts/en/adapters/portal.md.j2`
+  - New portal-specific guidance for MCP destructive actions and UI confirmations.
+
+- `prompts/en/channel.md.j2`
+  - Added explicit instruction that MCP-backed infrastructure actions are worker tasks.
+
+- `src/prompts/engine.rs`
+  - Registered the `portal` adapter prompt and added prompt tests.
+
+- `src/prompts/text.rs`
+  - Registered the new `adapters/portal` prompt text entry.
+
+## Files Changed In `spacebot-homelab-mcp`
+
+These were compatibility/documentation changes made in this repo so users understand the client dependency.
+
+- `README.md`
+  - Added a compatibility note explaining that `[confirm]` rules require MCP client support for `confirm_operation`.
+
+- `example.config.toml`
+  - Added the same warning above the commented `[confirm]` examples.
+
+## Compatibility Guidance
+
+If a user's Spacebot build or UI does not surface pending MCP confirmations yet:
+
+1. Leave the `[confirm]` section disabled for homelab MCP tools.
+2. Use `dry_run=true` before destructive operations.
+3. Re-enable `[confirm]` once the client supports the MCP confirmation flow.
+
+This is especially important for:
+
+- `proxmox.vm.stop`
+- `proxmox.vm.create`
+- `proxmox.vm.delete`
+- `proxmox.vm.snapshot.rollback`
+- Docker destructive operations with `always` confirmation enabled
+
+## Expected Web UI Flow
+
+For a destructive request like `stop VM 100 on proxmox-homelab`:
+
+1. The channel agent spawns a worker.
+2. The worker calls `proxmox.vm.stop`.
+3. `spacebot-homelab-mcp` returns `confirmation_required` with a token.
+4. Spacebot stores the pending confirmation for the portal conversation.
+5. The web UI shows a confirmation card.
+6. The user clicks `Confirm action`.
+7. Spacebot backend calls `confirm_operation`.
+8. The final tool result is posted back into the chat transcript.
+
+## Validation Notes
+
+The web UI integration was validated by:
+
+- enabling Proxmox confirmation rules in the active homelab MCP config
+- confirming pending confirmations appeared in the portal UI
+- confirming the second-step execution succeeded through `confirm_operation`
+
+## Upstream Takeaway
+
+The confirmation system in `spacebot-homelab-mcp` is correct and useful, but it depends on client support.
+
+When users report that destructive homelab MCP commands appear to stall or require awkward plain-text confirmation loops, the likely issue is not the MCP server itself. The likely issue is that the client has not yet implemented the MCP `confirm_operation` UX.

--- a/SPACEBOT-UI-CONFIRMATION-INTEGRATION.md
+++ b/SPACEBOT-UI-CONFIRMATION-INTEGRATION.md
@@ -34,6 +34,13 @@ Before the Spacebot web UI changes, the user-visible failure mode was:
 3. The agent could get stuck in a text-only confirmation loop.
 4. In practice, users often had to disable `[confirm]` rules for destructive homelab commands.
 
+After the initial web UI implementation, retesting surfaced two more client-side issues:
+
+1. The web UI could render the confirmation card before the assistant's pre-confirmation explanation text arrived.
+2. Workers could still describe a destructive MCP action with past-tense success wording even when the MCP tool had only returned `confirmation_required`.
+
+These were follow-up `spacebot` issues, not `spacebot-homelab-mcp` protocol issues, and were fixed in later iterations.
+
 ## What Already Existed In `spacebot-homelab-mcp`
 
 The MCP server already had the correct server-side behavior:
@@ -66,6 +73,7 @@ The main Spacebot app needed both backend and frontend work.
 - provide `Confirm action` and `Dismiss` controls
 - remove the card when resolved
 - show the confirmed result back in the chat transcript
+- delay rendering the confirmation card until the assistant's pre-confirmation message arrives, with a short fallback timeout if the message is delayed
 
 ### Prompting / Agent Behavior
 
@@ -75,6 +83,8 @@ The Spacebot channel prompt also needed updates so the agent would:
 - stop saying things like `Stopping it now` without actually calling tools
 - use a worker for MCP-backed infrastructure actions
 - call the destructive MCP tool first, then let the UI handle confirmation
+- treat `confirmation_required` as a terminal pre-confirmation state, not as a successful execution result
+- keep pre-confirmation and post-confirmation messaging separate
 
 ## Files Changed In `spacebot`
 
@@ -112,6 +122,7 @@ The Spacebot channel prompt also needed updates so the agent would:
   - Added the visible confirmation card UI.
   - Added confirm and dismiss actions.
   - Added live updates for pending/resolved confirmations.
+  - Added delayed confirmation-card reveal so the explanatory assistant message can land before the user sees the confirm controls.
 
 - `interface/src/hooks/useLiveContext.tsx`
   - Bridged backend confirmation events into browser events for the portal chat UI.
@@ -120,12 +131,18 @@ The Spacebot channel prompt also needed updates so the agent would:
 
 - `prompts/en/adapters/portal.md.j2`
   - New portal-specific guidance for MCP destructive actions and UI confirmations.
+  - Clarified that pre-confirmation messaging must describe pending confirmation only, and post-confirmation messaging should be a separate executed result.
 
 - `prompts/en/channel.md.j2`
   - Added explicit instruction that MCP-backed infrastructure actions are worker tasks.
 
+- `prompts/en/worker.md.j2`
+  - Added explicit worker guidance that `confirmation_required` means the destructive action has NOT executed yet.
+  - Prevents worker summaries from using past-tense success wording before the user confirms in the web UI.
+
 - `src/prompts/engine.rs`
   - Registered the `portal` adapter prompt and added prompt tests.
+  - Added worker-prompt coverage to verify `confirmation_required` guidance stays in the worker system prompt.
 
 - `src/prompts/text.rs`
   - Registered the new `adapters/portal` prompt text entry.
@@ -164,10 +181,11 @@ For a destructive request like `stop VM 100 on proxmox-homelab`:
 2. The worker calls `proxmox.vm.stop`.
 3. `spacebot-homelab-mcp` returns `confirmation_required` with a token.
 4. Spacebot stores the pending confirmation for the portal conversation.
-5. The web UI shows a confirmation card.
-6. The user clicks `Confirm action`.
-7. Spacebot backend calls `confirm_operation`.
-8. The final tool result is posted back into the chat transcript.
+5. Spacebot sends a pre-confirmation assistant message explaining that the action is pending confirmation.
+6. The web UI shows a confirmation card after that explanatory message arrives, with a short fallback delay if needed.
+7. The user clicks `Confirm action`.
+8. Spacebot backend calls `confirm_operation`.
+9. The final tool result is posted back into the chat transcript.
 
 ## Validation Notes
 
@@ -176,6 +194,9 @@ The web UI integration was validated by:
 - enabling Proxmox confirmation rules in the active homelab MCP config
 - confirming pending confirmations appeared in the portal UI
 - confirming the second-step execution succeeded through `confirm_operation`
+- confirming that destructive MCP replies no longer rely on plain-text `confirm ...` loops
+- confirming that pre-confirmation text and the confirmation card appear in the intended order
+- confirming that worker summaries treat `confirmation_required` as pending, not executed
 
 ## Upstream Takeaway
 

--- a/example.config.toml
+++ b/example.config.toml
@@ -17,7 +17,8 @@ url = "https://192.168.1.10:8006"
 token_id = "root@pam!spacebot"
 token_secret = "${PVE_TOKEN_SECRET}"  # Use env var for the API token secret
 node = "pve1"                          # Optional: node name (auto-detected if omitted)
-verify_tls = false                     # Accept self-signed certs (default: false)
+verify_tls = false                     # Accept self-signed certs (default: true)
+task_wait_timeout_secs = 600           # Optional: local wait budget before returning the task UPID
 
 # Multi-node cluster example
 # [proxmox.hosts.pve2]

--- a/example.config.toml
+++ b/example.config.toml
@@ -19,6 +19,8 @@ token_secret = "${PVE_TOKEN_SECRET}"  # Use env var for the API token secret
 node = "pve1"                          # Optional: node name (auto-detected if omitted)
 verify_tls = false                     # Accept self-signed certs (default: true)
 task_wait_timeout_secs = 600           # Optional: local wait budget before returning the task UPID
+next_vmid_retry_attempts = 3           # Optional: retries when auto-assigned VMIDs race /cluster/nextid
+next_vmid_retry_backoff_ms = 250       # Optional: backoff between auto-assigned VMID retries
 
 # Multi-node cluster example
 # [proxmox.hosts.pve2]

--- a/example.config.toml
+++ b/example.config.toml
@@ -11,6 +11,21 @@ host = "unix:///var/run/docker.sock"
 [docker.hosts.vps]
 host = "tcp://vps.example.com:2375"
 
+# Proxmox VE hosts
+[proxmox.hosts.pve1]
+url = "https://192.168.1.10:8006"
+token_id = "root@pam!spacebot"
+token_secret = "${PVE_TOKEN_SECRET}"  # Use env var for the API token secret
+node = "pve1"                          # Optional: node name (auto-detected if omitted)
+verify_tls = false                     # Accept self-signed certs (default: false)
+
+# Multi-node cluster example
+# [proxmox.hosts.pve2]
+# url = "https://192.168.1.11:8006"
+# token_id = "automation@pve!spacebot"
+# token_secret = "${PVE2_TOKEN_SECRET}"
+# node = "pve2"
+
 # SSH hosts
 [ssh.hosts.home]
 host = "192.168.1.1"
@@ -97,6 +112,7 @@ file = "/var/log/spacebot-homelab/audit.log"
 "docker.image.*" = { per_minute = 5 }
 "docker.image.delete" = { per_minute = 1 }
 "docker.image.prune" = { per_minute = 1 }
+"proxmox.*" = { per_minute = 15 }
 
 # Tools configuration (optional)
 # If the [tools] section is omitted entirely, all tools are enabled.
@@ -116,33 +132,40 @@ file = "/var/log/spacebot-homelab/audit.log"
 #     "docker.image.inspect",
 #     "docker.image.delete",      # Destructive — requires confirmation
 #     "docker.image.prune",       # Destructive — requires confirmation
+#     "proxmox.node.list",
+#     "proxmox.node.status",
+#     "proxmox.vm.list",
+#     "proxmox.vm.status",
+#     "proxmox.vm.start",
+#     "proxmox.vm.stop",              # Destructive — requires confirmation
+#     "proxmox.vm.create",            # Destructive — requires confirmation
+#     "proxmox.vm.clone",
+#     "proxmox.vm.delete",            # Destructive — requires confirmation
+#     "proxmox.vm.snapshot.list",
+#     "proxmox.vm.snapshot.create",
+#     "proxmox.vm.snapshot.rollback", # Destructive — requires confirmation
+#     "proxmox.storage.list",
+#     "proxmox.network.list",
 #     "ssh.exec",
 #     "ssh.upload",
 #     "ssh.download",
 # ]
 
 # Confirmation rules for destructive operations (Layer 8 security)
-# Keys are rule names; each rule matches a tool + optional command pattern.
-# [confirm.restart_services]
-# tool = "ssh.exec"
-# when_pattern = "systemctl restart"
-# message = "This will restart a systemd service. Please confirm."
-#
-# [confirm.stop_containers]
-# tool = "docker.container.stop"
-# message = "This will stop a running container. Please confirm."
-#
-# [confirm.delete_containers]
-# tool = "docker.container.delete"
-# message = "This will permanently delete a container. Please confirm."
-#
-# [confirm.delete_images]
-# tool = "docker.image.delete"
-# message = "This will permanently delete an image. Please confirm."
-#
-# [confirm.prune_images]
-# tool = "docker.image.prune"
-# message = "This will prune unused images. Please confirm."
+# NOTE: Enable this only if your MCP client can complete the two-step
+# `confirm_operation` flow. If your Spacebot build/UI does not yet surface
+# pending confirmations, leave this section commented out and use `dry_run`
+# for destructive commands until confirmation UX support is available.
+# [confirm]
+# "ssh.exec" = { when_pattern = ["systemctl restart"] }
+# "docker.container.stop" = "always"
+# "docker.container.delete" = "always"
+# "docker.image.delete" = "always"
+# "docker.image.prune" = "always"
+# "proxmox.vm.stop" = "always"
+# "proxmox.vm.create" = "always"
+# "proxmox.vm.delete" = "always"
+# "proxmox.vm.snapshot.rollback" = "always"
 
 # Docker host with TLS (optional)
 # [docker.hosts.secure-remote]

--- a/skills/proxmox-admin/SKILL.md
+++ b/skills/proxmox-admin/SKILL.md
@@ -339,7 +339,7 @@ Check:
 Symptoms: connection refused or TLS handshake failure.
 
 Check:
-- `verify_tls = false` in config (default for homelab self-signed certs).
+- `verify_tls` defaults to `true` in `src/config.rs`; set `verify_tls = false` only as an explicit opt-out for trusted self-signed homelab environments, because it disables certificate verification and weakens transport security.
 - The Proxmox host is reachable on port 8006.
 - No firewall blocking the connection between Spacebot's host and the Proxmox host.
 

--- a/skills/proxmox-admin/SKILL.md
+++ b/skills/proxmox-admin/SKILL.md
@@ -1,0 +1,391 @@
+---
+name: proxmox-admin
+description: Manage Proxmox VE VM/CT lifecycle, resource planning, templates, snapshots, storage, VLAN configuration, and troubleshooting. Covers QEMU VMs and LXC containers, clone-based provisioning, VMID numbering, storage pool selection, network bridge setup, and common failure modes.
+version: 1.0.0
+---
+
+# Proxmox VE Administration
+
+## Purpose
+
+Use this skill when a Spacebot agent needs to create, manage, troubleshoot, or plan Proxmox VE virtual machines and LXC containers. This includes day-to-day lifecycle operations, template-based provisioning, snapshot management, resource capacity planning, storage selection, and network/VLAN configuration.
+
+This playbook separates five commonly conflated areas:
+
+- **QEMU VMs vs LXC containers** -- different resource models, different use cases, different API paths.
+- **Template cloning vs fresh creation** -- cloning is the standard provisioning path; direct creation is for bootstrapping templates.
+- **Linked clones vs full clones** -- different storage and performance tradeoffs.
+- **Storage types and content restrictions** -- not every storage pool can hold every content type.
+- **Network bridges vs VLANs vs bonds** -- distinct layers of network configuration on a Proxmox host.
+
+## When to invoke this skill
+
+- A VM or CT needs to be created, started, stopped, cloned, or deleted.
+- A template needs to be created from an existing VM for repeatable provisioning.
+- Snapshots need to be taken before risky changes, or rolled back after failures.
+- Storage capacity is running low and the agent needs to assess pool usage.
+- A new service needs a VM/CT and the agent must choose the right type, size, storage pool, and VLAN.
+- Network bridges or VLAN-tagged interfaces need to be verified or planned.
+- A Proxmox API call fails and the agent needs to diagnose the cause.
+- The agent needs to understand which VMID range to use for a new workload.
+
+## Available MCP tools
+
+This skill depends on the following Spacebot MCP tools:
+
+| Tool | Purpose | Confirmation Required |
+|------|---------|----------------------|
+| `proxmox.node.list` | List cluster nodes with CPU, memory, uptime | No |
+| `proxmox.node.status` | Detailed node status | No |
+| `proxmox.vm.list` | List VMs/CTs on a node (filter by qemu/lxc) | No |
+| `proxmox.vm.status` | Detailed VM/CT status (CPU, memory, disk, network I/O) | No |
+| `proxmox.vm.start` | Start a VM/CT | No |
+| `proxmox.vm.stop` | Graceful shutdown of a VM/CT | Yes |
+| `proxmox.vm.create` | Create a new VM/CT | Yes |
+| `proxmox.vm.clone` | Clone a VM from a template or existing VM | No |
+| `proxmox.vm.delete` | Permanently delete a VM/CT | Yes |
+| `proxmox.vm.snapshot.list` | List snapshots for a VM/CT | No |
+| `proxmox.vm.snapshot.create` | Create a snapshot | No |
+| `proxmox.vm.snapshot.rollback` | Rollback to a previous snapshot (current state lost) | Yes |
+| `proxmox.storage.list` | List storage pools with usage | No |
+| `proxmox.network.list` | List network interfaces (bridges, VLANs, bonds) | No |
+
+Additionally, `ssh.exec` may be used for operations not covered by the Proxmox API (e.g., editing `/etc/network/interfaces`, running `qm` or `pct` CLI commands directly, checking kernel modules).
+
+## Environment variables
+
+Throughout this skill, the following placeholders are used. The agent must resolve these to actual values from the user's environment before executing operations.
+
+| Placeholder | Meaning | Example |
+|---|---|---|
+| `<PVE_HOST>` | Proxmox host config name in Spacebot | `pve1` |
+| `<NODE>` | Proxmox node name within the cluster | `pve1` |
+| `<VMID>` | Numeric VM/CT identifier | `100` |
+| `<TEMPLATE_VMID>` | VMID of a template to clone from | `9000` |
+| `<STORAGE>` | Storage pool name | `local-lvm` |
+| `<BRIDGE>` | Network bridge name | `vmbr0` |
+| `<VLAN_TAG>` | 802.1Q VLAN tag number | `50` |
+| `<SUBNET_CIDR>` | Network range for the VLAN/bridge | `10.0.50.0/24` |
+| `<ISO_PATH>` | ISO image path in Proxmox storage | `local:iso/ubuntu-24.04.iso` |
+
+## High-confidence lessons learned
+
+These patterns recur across Proxmox homelab environments and represent the most common mistakes and best practices.
+
+1. **Always clone from templates; never build from scratch repeatedly.**
+   - Create a golden template VM (e.g., VMID 9000-9099), install the OS, run cloud-init or your setup script, convert to template.
+   - All future VMs of that type are cloned from the template. This is faster, more consistent, and reduces manual error.
+   - Templates cannot be started. They must be cloned first.
+
+2. **Use full clones for production, linked clones for ephemeral/test.**
+   - **Full clone:** independent copy of all disks. No dependency on the template. Safe to delete the template later. Higher storage cost.
+   - **Linked clone:** CoW snapshot-based. Very fast to create, uses minimal initial storage. Depends on the template -- if the template is deleted or corrupted, the clone breaks. Good for dev/test VMs that will be destroyed soon.
+
+3. **VMID numbering conventions prevent collisions and confusion.**
+   - Common pattern: `100-199` infrastructure VMs, `200-299` application VMs, `300-399` LXC containers, `9000-9099` templates.
+   - The exact ranges don't matter -- what matters is having a convention and following it.
+   - Use `proxmox.vm.list` to see existing VMIDs before creating new ones. The API's `/cluster/nextid` endpoint returns the next available VMID, but it doesn't respect numbering conventions.
+
+4. **Stop a VM before deleting it.**
+   - The Proxmox API will reject a delete request for a running VM. Always stop first, then delete.
+   - Use `proxmox.vm.status` to confirm it's stopped before calling `proxmox.vm.delete`.
+
+5. **Snapshot before risky changes, not after.**
+   - Before modifying a VM's configuration, upgrading software, or changing network settings: create a snapshot.
+   - Name snapshots descriptively: `pre-upgrade-2024-01-15`, `before-network-change`, not `snap1`.
+   - Snapshots with RAM state (`vmstate=true`) allow resuming from the exact point. Without RAM state, the VM will boot fresh from the snapshot's disk state.
+
+6. **Storage pool content types matter.**
+   - `local` (directory storage) typically holds ISOs and container templates.
+   - `local-lvm` (LVM thin) typically holds VM disk images and CT rootfs.
+   - Not all storage types support all content. Check `proxmox.storage.list` to see the `content` field for each pool.
+   - ZFS pools can hold both images and rootfs but have different performance characteristics than LVM thin.
+
+7. **LXC containers are lighter than QEMU VMs but less isolated.**
+   - Use LXC for trusted, single-purpose services (Pi-hole, nginx reverse proxy, monitoring agents).
+   - Use QEMU for anything needing full kernel isolation, custom kernels, or running non-Linux OSes.
+   - LXC containers share the host kernel. This means no custom kernel modules, no different kernel versions, and a smaller security boundary.
+
+8. **The Proxmox API uses async tasks for mutating operations.**
+   - POST requests for start, stop, create, clone, delete, and snapshot operations return a UPID (Unique Process ID) string.
+   - The Spacebot tools automatically poll the task status and wait for completion (up to 120 seconds).
+   - If a tool returns a timeout message, the task may still be running. Check the Proxmox web UI or use SSH to run `qm status <VMID>`.
+
+## Symptoms classification
+
+Use the first matching category.
+
+### 1) VM/CT won't start
+
+Typical signs:
+- `proxmox.vm.start` returns an error or the task fails.
+- The VM appears as "stopped" after a start attempt.
+
+Most likely causes:
+- **Insufficient resources:** not enough free RAM or CPU on the node.
+- **Storage not available:** the storage pool holding the VM's disk is inactive or full.
+- **Lock file:** a previous operation left a lock (`.lock` file). Common after a failed migration or snapshot.
+- **Missing ISO:** the VM config references an ISO that's been moved or deleted.
+
+First actions:
+1. `proxmox.node.status` -- check available RAM and CPU.
+2. `proxmox.storage.list` -- check storage pool health and free space.
+3. `proxmox.vm.status` -- look for lock indicators in the output.
+4. Via SSH: `qm config <VMID>` to inspect the full VM configuration.
+
+### 2) VM/CT is unreachable on the network after creation
+
+Typical signs:
+- VM is running (status shows "running") but cannot be pinged or accessed on the expected IP.
+- Other VMs on the same bridge work fine.
+
+Most likely causes:
+- **Wrong bridge:** the VM's network interface is attached to the wrong `vmbr` bridge.
+- **Missing VLAN tag:** if VLANs are in use, the VM's NIC may need a VLAN tag that wasn't set.
+- **No IP configured inside the VM:** the VM booted but cloud-init or DHCP didn't run, or the network config inside the guest is wrong.
+- **Firewall:** Proxmox has a built-in firewall that can block traffic if enabled but not configured.
+
+First actions:
+1. `proxmox.vm.status` -- confirm it's actually running.
+2. `proxmox.network.list` -- verify the bridge exists and is active.
+3. Via SSH to Proxmox host: `qm config <VMID>` to check the `net0` line.
+4. Via SSH: `qm guest exec <VMID> -- ip addr` (requires qemu-guest-agent) to check the guest's network config.
+
+### 3) Clone operation fails or is extremely slow
+
+Typical signs:
+- `proxmox.vm.clone` returns a task timeout.
+- The clone appears to start but never completes.
+
+Most likely causes:
+- **Full clone on slow storage:** full clones of large disks on HDD-backed storage can take a very long time.
+- **Source VM is running:** cloning a running VM requires more I/O and may be slower. Prefer cloning stopped VMs or templates.
+- **Storage pool full:** not enough free space on the target storage for the cloned disk.
+
+First actions:
+1. `proxmox.storage.list` -- check free space on the target storage.
+2. Consider using a linked clone instead if the workload is ephemeral.
+3. If possible, stop the source VM before cloning.
+
+### 4) Snapshot rollback fails
+
+Typical signs:
+- `proxmox.vm.snapshot.rollback` returns an error.
+- The VM state does not change after the rollback.
+
+Most likely causes:
+- **VM is running:** some snapshot configurations require the VM to be stopped before rollback.
+- **Snapshot chain corruption:** if the underlying storage has issues, snapshot metadata can become inconsistent.
+- **Wrong snapshot name:** the snapshot name is case-sensitive.
+
+First actions:
+1. `proxmox.vm.snapshot.list` -- confirm the snapshot name exists.
+2. Stop the VM first, then retry the rollback.
+3. Via SSH: `qm snapshot <VMID> list` for additional detail.
+
+### 5) Storage pool shows high usage or errors
+
+Typical signs:
+- `proxmox.storage.list` shows a pool at >90% usage.
+- VM creation or clone fails with "no space left" errors.
+
+Most likely causes:
+- **Orphaned disk images:** deleted VMs may have left disk images behind.
+- **Snapshot accumulation:** many snapshots over time consume significant space on LVM thin and ZFS.
+- **Thin provisioning overcommit:** LVM thin pools can overcommit, making the apparent usage lower than reality.
+
+First actions:
+1. `proxmox.storage.list` -- get current usage numbers.
+2. `proxmox.vm.list` -- identify VMs that can be cleaned up.
+3. `proxmox.vm.snapshot.list` on suspect VMs -- identify old snapshots to remove.
+4. Via SSH: `lvs` or `zfs list -t snapshot` to see actual disk-level usage.
+
+## Decision tree
+
+Follow in order when provisioning a new workload.
+
+### Step 1: QEMU VM or LXC container?
+
+**Use LXC if:**
+- The workload is a single Linux service (DNS, reverse proxy, monitoring agent).
+- You want minimal resource overhead.
+- You don't need custom kernel modules or a non-Linux OS.
+- The workload is trusted (same trust boundary as the host kernel).
+
+**Use QEMU if:**
+- You need full OS isolation (different kernel, Windows, BSD).
+- The workload is untrusted or multi-tenant.
+- You need GPU passthrough, PCI passthrough, or custom hardware access.
+- You need to run Docker-in-VM (Docker inside LXC is fragile).
+
+### Step 2: Clone from template or create fresh?
+
+**Clone from template if:**
+- A template exists for the desired OS/base image.
+- This is a standard deployment (not a one-off experiment with a new OS).
+
+**Create fresh if:**
+- You're bootstrapping a new template (first VM of its kind).
+- You need to install from an ISO that hasn't been templated yet.
+
+To clone:
+1. Identify the template VMID: `proxmox.vm.list` (look for template entries or known template VMIDs in the user's convention).
+2. `proxmox.vm.clone` with `vmid=<TEMPLATE_VMID>`, `name=<new-name>`, `full=true` (or `false` for linked).
+3. After clone completes, `proxmox.vm.start` to boot the new VM.
+
+To create fresh:
+1. `proxmox.vm.create` with cores, memory, storage, ISO, and network parameters.
+2. `proxmox.vm.start` to boot from the ISO.
+3. After OS installation, consider converting to template for future use.
+
+### Step 3: Choose resource sizing
+
+**Typical homelab sizing (starting points, adjust based on workload):**
+
+| Workload | Type | Cores | RAM | Disk |
+|----------|------|-------|-----|------|
+| Pi-hole / DNS | LXC | 1 | 256 MB | 4 GB |
+| Nginx reverse proxy | LXC | 1 | 512 MB | 8 GB |
+| Docker host (light) | QEMU | 2 | 2 GB | 32 GB |
+| Docker host (medium) | QEMU | 4 | 8 GB | 64 GB |
+| Plex/Jellyfin | QEMU | 4 | 4 GB | 32 GB + media mount |
+| Database (Postgres/MySQL) | QEMU | 2 | 4 GB | 32 GB |
+| Home Assistant | QEMU | 2 | 2 GB | 32 GB |
+| Windows desktop | QEMU | 4 | 8 GB | 64 GB |
+
+Always check available resources first: `proxmox.node.status` for node-level capacity.
+
+### Step 4: Choose storage pool
+
+1. `proxmox.storage.list` -- see available pools and their free space.
+2. Match content type: VM disk images need a pool with `images` in its content field. CT rootfs needs `rootdir`. ISOs need `iso`.
+3. Prefer local fast storage (SSD/NVMe-backed LVM thin or ZFS) for OS disks.
+4. Use NFS/CIFS for bulk media storage or backups.
+
+### Step 5: Choose network configuration
+
+1. `proxmox.network.list` -- see available bridges and VLANs.
+2. Default: `virtio,bridge=vmbr0` (standard paravirtualized NIC on the main bridge).
+3. If VLANs are in use: `virtio,bridge=vmbr0,tag=<VLAN_TAG>`.
+4. For isolated networks: use a separate bridge (e.g., `vmbr1` for an internal-only network).
+
+## VMID numbering conventions
+
+The agent should follow the user's established convention. If no convention exists, suggest:
+
+| Range | Purpose |
+|-------|---------|
+| 100-199 | Infrastructure VMs (DNS, DHCP, reverse proxy, monitoring) |
+| 200-299 | Application VMs (Docker hosts, databases, media servers) |
+| 300-399 | LXC containers |
+| 400-499 | Test/ephemeral VMs |
+| 9000-9099 | Templates (QEMU) |
+| 9100-9199 | Templates (LXC) |
+
+Check existing VMIDs with `proxmox.vm.list` before choosing a new one.
+
+## Template management
+
+### Creating a template from an existing VM
+
+Templates are created via the Proxmox CLI (not the REST API):
+
+```bash
+# Via SSH to the Proxmox host:
+qm template <VMID>
+```
+
+Before converting:
+1. Ensure the VM is stopped.
+2. Install and configure cloud-init (for automated hostname, SSH key, network setup on clone).
+3. Clean up: remove SSH host keys, machine-id, bash history.
+4. The VM becomes permanently read-only after conversion. It cannot be started, only cloned.
+
+### Cloud-init integration
+
+For QEMU templates with cloud-init:
+1. Add a cloud-init drive: `qm set <VMID> --ide2 <STORAGE>:cloudinit`
+2. Set defaults: `qm set <VMID> --ciuser admin --sshkeys ~/.ssh/authorized_keys --ipconfig0 ip=dhcp`
+3. Clones inherit these settings but can override them before first boot.
+
+## Safety rules
+
+1. **Snapshot before destructive operations.** Before stopping, deleting, or rolling back a VM, create a snapshot first if the VM has unsaved state.
+
+2. **Use dry_run on mutating tools.** All mutating Proxmox tools support `dry_run=true`. Use it to preview the operation before executing.
+
+3. **Confirm destructive tools require two steps.** Tools marked with "Confirmation Required" return a confirmation token on first call. The agent must call `confirm_operation` with that token to execute. This prevents accidental destruction.
+
+4. **Never delete a template that has linked clones.** Linked clones depend on the template's disk. Deleting the template will corrupt all linked clones. Use `proxmox.vm.list` to check for VMs that might be linked clones before deleting a template.
+
+5. **Stop before delete.** A running VM cannot be deleted. Always stop first, verify it's stopped, then delete.
+
+6. **Check node capacity before creating VMs.** Don't overcommit RAM beyond ~80% of physical unless the workloads are known to be light. CPU overcommit is generally fine up to 4:1 for typical homelab loads.
+
+## Troubleshooting: API connectivity issues
+
+### Authentication failures
+
+Symptoms: HTTP 401 from any Proxmox tool.
+
+Check:
+- Token ID format: must be `USER@REALM!TOKENID` (e.g., `root@pam!spacebot`).
+- Token secret: must be the UUID returned when the token was created.
+- `--privsep 0` on the token: if privilege separation is enabled (default), the token needs its own ACL entries.
+- Token hasn't expired (tokens can have expiration dates).
+
+### TLS/certificate errors
+
+Symptoms: connection refused or TLS handshake failure.
+
+Check:
+- `verify_tls = false` in config (default for homelab self-signed certs).
+- The Proxmox host is reachable on port 8006.
+- No firewall blocking the connection between Spacebot's host and the Proxmox host.
+
+### Permission denied on specific operations
+
+Symptoms: HTTP 403 on a tool that previously worked.
+
+Check:
+- The API token user has the required role. `PVEVMAdmin` covers most VM operations. `PVEAdmin` covers everything.
+- ACLs may be scoped to specific paths (e.g., `/vms/100` instead of `/`). Ensure the token has permissions on the target VMID's path.
+
+## Recommended procedural flow for agents
+
+When managing Proxmox VMs/CTs:
+
+1. **Assess current state:** `proxmox.node.list`, `proxmox.vm.list`, `proxmox.storage.list`.
+2. **Check capacity:** `proxmox.node.status` for CPU/RAM availability.
+3. **Determine VM type:** QEMU or LXC based on the workload (see decision tree).
+4. **Choose provisioning method:** clone from template (preferred) or create fresh.
+5. **Select VMID:** follow the user's numbering convention or suggest one.
+6. **Select storage:** match content type to pool, prefer fast local storage for OS disks.
+7. **Select network:** bridge + VLAN tag based on the network segment for this workload.
+8. **Preview with dry_run:** use `dry_run=true` on create/clone/delete before executing.
+9. **Execute and verify:** run the operation, then verify with `proxmox.vm.status`.
+10. **Snapshot after stable state:** once the VM is configured and working, take a snapshot as a restore point.
+
+## Fast diagnosis cheatsheet
+
+| Symptom | Most likely fix |
+|---|---|
+| VM won't start: "not enough memory" | Check `proxmox.node.status`; reduce VM memory or stop unused VMs |
+| VM won't start: "storage not active" | Check `proxmox.storage.list`; remount or repair the storage pool |
+| VM starts but no network | Check `net0` config via SSH `qm config <VMID>`; verify bridge and VLAN tag |
+| Clone fails with timeout | Check storage free space; use linked clone for speed; stop source VM first |
+| Delete returns error | Stop the VM first, then retry delete |
+| API returns 401 | Verify token_id format (`USER@REALM!TOKENID`) and token_secret |
+| API returns 403 on specific VM | Check ACL scope -- token may lack permissions on that VMID path |
+| Snapshot rollback fails | Stop the VM first, verify snapshot name with `proxmox.vm.snapshot.list` |
+| Storage pool >90% full | Remove old snapshots, delete unused VMs, check for orphaned disks via SSH |
+
+## References
+
+See supporting reference docs in `references/`:
+
+- `vm-lifecycle.md` -- step-by-step VM/CT creation, cloning, deletion procedures.
+- `snapshot-management.md` -- snapshot creation, rollback, and cleanup patterns.
+- `storage-planning.md` -- storage pool types, content restrictions, and capacity planning.
+- `network-configuration.md` -- bridge setup, VLAN tagging, and common network patterns.
+- `api-troubleshooting.md` -- Proxmox API authentication, permissions, and error diagnosis.

--- a/skills/proxmox-admin/SKILL.md
+++ b/skills/proxmox-admin/SKILL.md
@@ -314,7 +314,7 @@ For QEMU templates with cloud-init:
 
 2. **Use dry_run on mutating tools.** All mutating Proxmox tools support `dry_run=true`. Use it to preview the operation before executing.
 
-3. **Confirm destructive tools require two steps.** Tools marked with "Confirmation Required" return a confirmation token on first call. The agent must call `confirm_operation` with that token to execute. This prevents accidental destruction.
+3. **Confirm destructive tools require two steps.** Tools marked with "Confirmation Required" return a confirmation token on first call. The agent must call `confirm_operation` with both that token and the original tool name to execute. This prevents accidental destruction.
 
 4. **Never delete a template that has linked clones.** Linked clones depend on the template's disk. Deleting the template will corrupt all linked clones. Use `proxmox.vm.list` to check for VMs that might be linked clones before deleting a template.
 

--- a/skills/proxmox-admin/SKILL.md
+++ b/skills/proxmox-admin/SKILL.md
@@ -40,7 +40,7 @@ This skill depends on the following Spacebot MCP tools:
 | `proxmox.vm.list` | List VMs/CTs on a node (filter by qemu/lxc) | No |
 | `proxmox.vm.status` | Detailed VM/CT status (CPU, memory, disk, network I/O) | No |
 | `proxmox.vm.start` | Start a VM/CT | No |
-| `proxmox.vm.stop` | Graceful shutdown of a VM/CT | Yes |
+| `proxmox.vm.stop` | Immediate (force) stop of a VM/CT; does not attempt graceful shutdown | Yes |
 | `proxmox.vm.create` | Create a new VM/CT | Yes |
 | `proxmox.vm.clone` | Clone a VM from a template or existing VM | No |
 | `proxmox.vm.delete` | Permanently delete a VM/CT | Yes |

--- a/skills/proxmox-admin/references/api-troubleshooting.md
+++ b/skills/proxmox-admin/references/api-troubleshooting.md
@@ -1,0 +1,182 @@
+# API Troubleshooting
+
+Proxmox VE API authentication, permissions, and error diagnosis reference for Spacebot agents.
+
+## API connectivity basics
+
+- **Default port:** 8006 (HTTPS)
+- **Base URL:** `https://<host>:8006/api2/json`
+- **Auth header:** `Authorization: PVEAPIToken=USER@REALM!TOKENID=UUID`
+- **POST body format:** `application/x-www-form-urlencoded` (not JSON)
+- **Response envelope:** `{"data": ...}` wraps all responses
+
+## HTTP status codes
+
+| Code | Meaning | Common cause |
+|------|---------|-------------|
+| 200 | Success | Normal operation |
+| 400 | Bad request | Invalid parameters (wrong VMID format, missing required field) |
+| 401 | Unauthorized | Bad token, expired token, wrong token format |
+| 403 | Forbidden | Token lacks permissions for this operation/path |
+| 404 | Not found | Wrong node name, VMID doesn't exist, wrong API path |
+| 500 | Internal server error | Proxmox bug or backend failure |
+| 595 | Connection error | Host unreachable, port blocked, TLS handshake failure |
+
+## Authentication issues
+
+### HTTP 401: Unauthorized
+
+**Check token format:**
+- Token ID must be `USER@REALM!TOKENID` (e.g., `root@pam!spacebot`).
+- Note the `!` separator between user and token name.
+- The realm is usually `pam` (Linux PAM) or `pve` (Proxmox VE).
+
+**Check token secret:**
+- Must be the UUID returned when the token was created.
+- Format: `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
+- Check for leading/trailing whitespace.
+
+**Check token existence:**
+```bash
+# On the Proxmox host:
+pveum user token list root@pam
+```
+
+**Check token expiration:**
+```bash
+pveum user token list root@pam --output-format json | jq '.[] | select(.tokenid=="spacebot")'
+```
+
+### Creating a new API token
+
+```bash
+# Full-privilege token (same as user):
+pveum user token add root@pam spacebot --privsep 0
+
+# Limited-privilege token (needs separate ACLs):
+pveum user token add root@pam spacebot --privsep 1
+pveum aclmod / -token 'root@pam!spacebot' -role PVEVMAdmin
+```
+
+`--privsep 0` gives the token the user's permissions. `--privsep 1` (default) requires you to assign roles to the token separately.
+
+## Permission issues
+
+### HTTP 403: Forbidden
+
+**Check user/token roles:**
+```bash
+pveum acl list
+pveum user list --output-format json
+```
+
+**Common roles:**
+
+| Role | Permissions |
+|------|-------------|
+| `PVEAdmin` | Full admin (everything except user management) |
+| `PVEVMAdmin` | VM/CT lifecycle: create, start, stop, delete, snapshots |
+| `PVEVMUser` | VM/CT use: start, stop, console, but not create/delete |
+| `PVEAuditor` | Read-only: list, status, but no mutations |
+| `PVEDatastoreAdmin` | Storage management |
+| `Administrator` | Full access including user management |
+
+**ACL paths:**
+
+ACLs can be scoped to specific paths:
+- `/` -- everything
+- `/vms/<VMID>` -- specific VM
+- `/storage/<STORAGE>` -- specific storage pool
+- `/nodes/<NODE>` -- specific node
+
+If a token has `PVEVMAdmin` on `/vms/100` but not on `/vms/200`, it can manage VM 100 but not VM 200.
+
+**Fix: grant broader permissions:**
+```bash
+# Grant PVEVMAdmin on all VMs:
+pveum aclmod /vms -token 'root@pam!spacebot' -role PVEVMAdmin
+
+# Or on everything:
+pveum aclmod / -token 'root@pam!spacebot' -role PVEAdmin
+```
+
+## TLS/connection issues
+
+### Self-signed certificate errors
+
+Proxmox uses a self-signed cert by default. Spacebot handles this with `verify_tls = false` in config.
+
+If connections still fail:
+- Check that port 8006 is reachable: `nc -vz <PVE_HOST_IP> 8006`
+- Check the Proxmox proxy service: `systemctl status pveproxy`
+- Check for firewall rules: `iptables -L -n` or `pve-firewall status`
+
+### Connection timeouts
+
+- Verify network path: `ping <PVE_HOST_IP>`.
+- Check if the `pveproxy` service is running: `systemctl status pveproxy`.
+- Check if another service is competing for port 8006.
+- Check DNS resolution if using hostname instead of IP.
+
+## Async task handling
+
+### UPID format
+
+Mutating operations return a UPID (Unique Process ID):
+```
+UPID:pve1:001A2B3C:04D5E6F7:6789ABCD:qmstart:100:root@pam:
+```
+
+Format: `UPID:{node}:{pid}:{pstart}:{starttime}:{type}:{id}:{user}:`
+
+### Task status polling
+
+Spacebot tools automatically poll task status. If a tool reports a timeout:
+
+1. The task may still be running. Check via SSH:
+   ```bash
+   # List recent tasks:
+   pvesh get /nodes/<NODE>/tasks --limit 5
+   
+   # Check specific task:
+   pvesh get /nodes/<NODE>/tasks/<UPID>/status
+   
+   # View task log:
+   pvesh get /nodes/<NODE>/tasks/<UPID>/log
+   ```
+
+2. Check the Proxmox web UI: Datacenter > Task History.
+
+### Common task failures
+
+| Task type | Common failure | Fix |
+|-----------|---------------|-----|
+| `qmstart` | "not enough memory" | Free RAM on the node or reduce VM memory |
+| `qmstart` | "storage not available" | Check storage pool status |
+| `qmclone` | timeout | Large disk + slow storage = long clone time; use linked clone |
+| `vzdestroy` | "VM is running" | Stop the VM first |
+| `qmsnapshot` | "not enough space" | Clean up old snapshots, free storage |
+
+## Rate limiting
+
+Proxmox doesn't enforce API rate limits, but rapid API calls can overload the `pveproxy` service.
+
+Spacebot supports rate limiting in config:
+```toml
+[tools.rate_limits]
+"proxmox.*" = { per_minute = 15 }
+```
+
+Recommended: keep read-only calls at 15-30/minute, mutating calls at 5-10/minute.
+
+## Debugging API responses
+
+To see raw API responses for debugging, use SSH:
+```bash
+# Direct API call from the Proxmox host:
+pvesh get /nodes/pve1/qemu/100/status/current --output-format json-pretty
+
+# Or using curl:
+curl -k -H "Authorization: PVEAPIToken=root@pam!spacebot=<UUID>" \
+  https://localhost:8006/api2/json/nodes/pve1/qemu/100/status/current | jq .
+```

--- a/skills/proxmox-admin/references/api-troubleshooting.md
+++ b/skills/proxmox-admin/references/api-troubleshooting.md
@@ -163,7 +163,7 @@ Proxmox doesn't enforce API rate limits, but rapid API calls can overload the `p
 
 Spacebot supports rate limiting in config:
 ```toml
-[tools.rate_limits]
+[rate_limits.limits]
 "proxmox.*" = { per_minute = 15 }
 ```
 

--- a/skills/proxmox-admin/references/network-configuration.md
+++ b/skills/proxmox-admin/references/network-configuration.md
@@ -4,7 +4,7 @@ Bridge setup, VLAN tagging, and common network patterns for Proxmox VE.
 
 ## Checking current network
 
-```
+```text
 proxmox.network.list (host=<PVE_HOST>)
 ```
 
@@ -37,7 +37,7 @@ The host's management IP is typically assigned to `vmbr0`, not the physical NIC.
 
 All VMs share one bridge, one subnet.
 
-```
+```text
 Physical NIC (eno1) <-> vmbr0 (10.0.1.0/24) <-> VMs
 ```
 
@@ -49,16 +49,16 @@ This is the simplest setup. All VMs are on the same L2 segment.
 
 One bridge handles multiple VLANs. The physical switch port must be configured as a trunk.
 
-```
+```text
 Physical NIC (eno1) <-> vmbr0 (VLAN-aware) <-> VMs with VLAN tags
 ```
 
 Configuration (in `/etc/network/interfaces`):
-```
+```ini
 auto vmbr0
 iface vmbr0 inet static
     address 10.0.1.1/24
-    gateway 10.0.1.1
+    gateway 10.0.1.254
     bridge-ports eno1
     bridge-stp off
     bridge-fd 0
@@ -76,7 +76,7 @@ VM NIC configs:
 
 Each VLAN gets its own bridge. More explicit, easier to reason about, but more config.
 
-```
+```text
 eno1.10 <-> vmbr1 (IoT VLAN 10)
 eno1.20 <-> vmbr2 (Media VLAN 20)
 eno1.50 <-> vmbr3 (Homelab VLAN 50)
@@ -88,7 +88,7 @@ VM NIC config: `virtio,bridge=vmbr1` (no tag needed, the bridge is already on th
 
 A bridge with no physical NIC attached. VMs on this bridge can only talk to each other.
 
-```
+```text
 vmbr99 (no bridge-ports) <-> VMs (isolated network)
 ```
 
@@ -116,7 +116,7 @@ pct config <VMID> | grep net
 ```
 
 Example output:
-```
+```text
 net0: virtio=AA:BB:CC:DD:EE:FF,bridge=vmbr0,tag=50
 ```
 
@@ -148,12 +148,12 @@ If the bridge's member port (physical NIC) is down, the bridge will be inactive.
 
 For redundancy or throughput, multiple NICs can be bonded:
 
-```
+```text
 bond0 (eno1 + eno2, LACP) <-> vmbr0 <-> VMs
 ```
 
 Configuration:
-```
+```ini
 auto bond0
 iface bond0 inet manual
     bond-slaves eno1 eno2
@@ -164,7 +164,7 @@ iface bond0 inet manual
 auto vmbr0
 iface vmbr0 inet static
     address 10.0.1.1/24
-    gateway 10.0.1.1
+    gateway 10.0.1.254
     bridge-ports bond0
     bridge-stp off
     bridge-fd 0

--- a/skills/proxmox-admin/references/network-configuration.md
+++ b/skills/proxmox-admin/references/network-configuration.md
@@ -1,0 +1,182 @@
+# Network Configuration
+
+Bridge setup, VLAN tagging, and common network patterns for Proxmox VE.
+
+## Checking current network
+
+```
+proxmox.network.list (host=<PVE_HOST>)
+```
+
+Output shows: interface name, type, IP address, active status, autostart, and bridge ports.
+
+## Network architecture overview
+
+Proxmox networking has three layers:
+
+1. **Physical NICs** (`eno1`, `enp3s0`, etc.) -- the actual hardware interfaces.
+2. **Linux bridges** (`vmbr0`, `vmbr1`, etc.) -- virtual switches that connect VMs to the network.
+3. **VLAN interfaces** (`vmbr0.50`, `eno1.10`, etc.) -- 802.1Q tagged sub-interfaces.
+
+VMs connect to bridges. Bridges connect to physical NICs (or VLAN-tagged sub-interfaces). This is the fundamental model.
+
+## Default network setup
+
+A fresh Proxmox installation creates:
+
+| Interface | Type | Purpose |
+|-----------|------|---------|
+| `eno1` (or similar) | Physical NIC | Uplink to the physical network |
+| `vmbr0` | Bridge | Main VM bridge, bridged to `eno1` |
+
+The host's management IP is typically assigned to `vmbr0`, not the physical NIC.
+
+## Common homelab patterns
+
+### Single flat network (no VLANs)
+
+All VMs share one bridge, one subnet.
+
+```
+Physical NIC (eno1) <-> vmbr0 (10.0.1.0/24) <-> VMs
+```
+
+VM NIC config: `virtio,bridge=vmbr0`
+
+This is the simplest setup. All VMs are on the same L2 segment.
+
+### VLAN-aware bridge
+
+One bridge handles multiple VLANs. The physical switch port must be configured as a trunk.
+
+```
+Physical NIC (eno1) <-> vmbr0 (VLAN-aware) <-> VMs with VLAN tags
+```
+
+Configuration (in `/etc/network/interfaces`):
+```
+auto vmbr0
+iface vmbr0 inet static
+    address 10.0.1.1/24
+    gateway 10.0.1.1
+    bridge-ports eno1
+    bridge-stp off
+    bridge-fd 0
+    bridge-vlan-aware yes
+    bridge-vids 2-4094
+```
+
+VM NIC configs:
+- Management VLAN (untagged): `virtio,bridge=vmbr0`
+- IoT VLAN 10: `virtio,bridge=vmbr0,tag=10`
+- Media VLAN 20: `virtio,bridge=vmbr0,tag=20`
+- Homelab VLAN 50: `virtio,bridge=vmbr0,tag=50`
+
+### Separate bridges per VLAN
+
+Each VLAN gets its own bridge. More explicit, easier to reason about, but more config.
+
+```
+eno1.10 <-> vmbr1 (IoT VLAN 10)
+eno1.20 <-> vmbr2 (Media VLAN 20)
+eno1.50 <-> vmbr3 (Homelab VLAN 50)
+```
+
+VM NIC config: `virtio,bridge=vmbr1` (no tag needed, the bridge is already on the VLAN).
+
+### Internal-only network
+
+A bridge with no physical NIC attached. VMs on this bridge can only talk to each other.
+
+```
+vmbr99 (no bridge-ports) <-> VMs (isolated network)
+```
+
+Useful for: database networks where VMs should only be accessible from app VMs, not from the LAN.
+
+## VLAN tag assignment for VMs
+
+When using a VLAN-aware bridge, set the VLAN tag on the VM's NIC:
+
+| Tool | How to set VLAN |
+|------|----------------|
+| `proxmox.vm.create` | `net="virtio,bridge=vmbr0,tag=50"` |
+| `proxmox.vm.clone` + SSH | After clone: `qm set <VMID> --net0 virtio,bridge=vmbr0,tag=50` |
+| Proxmox Web UI | Hardware > Network Device > VLAN Tag |
+
+## Checking VM network config
+
+Via SSH to the Proxmox host:
+```bash
+# QEMU VM:
+qm config <VMID> | grep net
+
+# LXC container:
+pct config <VMID> | grep net
+```
+
+Example output:
+```
+net0: virtio=AA:BB:CC:DD:EE:FF,bridge=vmbr0,tag=50
+```
+
+## Network troubleshooting
+
+### VM has no network connectivity
+
+1. **Check VM status:** `proxmox.vm.status` -- is it running?
+2. **Check bridge:** `proxmox.network.list` -- is the bridge active?
+3. **Check VM NIC config:** SSH `qm config <VMID> | grep net` -- correct bridge and VLAN tag?
+4. **Check guest network:** SSH `qm guest exec <VMID> -- ip addr` (needs qemu-guest-agent).
+5. **Check physical switch:** if using VLANs, is the switch port configured as a trunk allowing the required VLAN?
+
+### VMs on different VLANs can't communicate
+
+This is expected behavior. VLANs isolate traffic. Communication between VLANs requires a router (firewall/gateway) that routes between the subnets. Typically this is OPNsense, pfSense, or the physical router.
+
+### Bridge shows inactive
+
+Check via SSH:
+```bash
+ip link show vmbr0
+brctl show vmbr0      # or: bridge link show
+```
+
+If the bridge's member port (physical NIC) is down, the bridge will be inactive. Check cable, switch port, and NIC status.
+
+## Bonding (link aggregation)
+
+For redundancy or throughput, multiple NICs can be bonded:
+
+```
+bond0 (eno1 + eno2, LACP) <-> vmbr0 <-> VMs
+```
+
+Configuration:
+```
+auto bond0
+iface bond0 inet manual
+    bond-slaves eno1 eno2
+    bond-miimon 100
+    bond-mode 802.3ad
+    bond-xmit-hash-policy layer3+4
+
+auto vmbr0
+iface vmbr0 inet static
+    address 10.0.1.1/24
+    gateway 10.0.1.1
+    bridge-ports bond0
+    bridge-stp off
+    bridge-fd 0
+```
+
+The physical switch must support LACP and have the ports configured for it.
+
+## Applying network changes
+
+Network changes to `/etc/network/interfaces` require either:
+- `ifreload -a` -- applies changes without reboot (Proxmox uses ifupdown2).
+- `systemctl restart networking` -- restarts networking (brief outage).
+- Reboot -- safest but most disruptive.
+
+**Warning:** incorrect network configuration can make the host unreachable. Always have IPMI/iLO/iDRAC access or physical console access as a fallback.

--- a/skills/proxmox-admin/references/snapshot-management.md
+++ b/skills/proxmox-admin/references/snapshot-management.md
@@ -11,7 +11,7 @@ Snapshot creation, rollback, and cleanup patterns for Proxmox VMs and LXC contai
 
 ## Creating a snapshot
 
-```
+```text
 proxmox.vm.snapshot.create (
   host=<PVE_HOST>,
   vmid=<VMID>,
@@ -42,7 +42,7 @@ RAM-state snapshots are larger and only available for QEMU VMs (not LXC).
 
 ## Listing snapshots
 
-```
+```text
 proxmox.vm.snapshot.list (host=<PVE_HOST>, vmid=<VMID>)
 ```
 
@@ -55,12 +55,12 @@ Snapshots form a tree. Each snapshot has a parent (except the first). The `curre
 **This is destructive.** All changes since the snapshot will be lost.
 
 1. **List snapshots to verify the target:**
-   ```
+   ```text
    proxmox.vm.snapshot.list (host=<PVE_HOST>, vmid=<VMID>)
    ```
 
 2. **Preview the rollback:**
-   ```
+   ```text
    proxmox.vm.snapshot.rollback (
      host=<PVE_HOST>,
      vmid=<VMID>,
@@ -70,22 +70,23 @@ Snapshots form a tree. Each snapshot has a parent (except the first). The `curre
    ```
 
 3. **Stop the VM first** (recommended for reliable rollback):
-   ```
+   ```text
    proxmox.vm.stop (host=<PVE_HOST>, vmid=<VMID>)
+   confirm_operation (token=<returned_token>, tool_name="proxmox.vm.stop")
    ```
 
 4. **Execute the rollback** (requires confirmation):
-   ```
+   ```text
    proxmox.vm.snapshot.rollback (
      host=<PVE_HOST>,
      vmid=<VMID>,
      snapname="pre-upgrade-2024-01-15"
    )
-   confirm_operation (token=<returned_token>)
+   confirm_operation (token=<returned_token>, tool_name="proxmox.vm.snapshot.rollback")
    ```
 
 5. **Start the VM:**
-   ```
+   ```text
    proxmox.vm.start (host=<PVE_HOST>, vmid=<VMID>)
    ```
 

--- a/skills/proxmox-admin/references/snapshot-management.md
+++ b/skills/proxmox-admin/references/snapshot-management.md
@@ -1,0 +1,133 @@
+# Snapshot Management
+
+Snapshot creation, rollback, and cleanup patterns for Proxmox VMs and LXC containers.
+
+## When to snapshot
+
+- **Before upgrades:** OS updates, kernel upgrades, major package changes.
+- **Before configuration changes:** network reconfig, storage changes, service migrations.
+- **Before risky operations:** anything that could leave the VM in a broken state.
+- **After reaching a known-good state:** baseline snapshot after initial setup.
+
+## Creating a snapshot
+
+```
+proxmox.vm.snapshot.create (
+  host=<PVE_HOST>,
+  vmid=<VMID>,
+  snapname="pre-upgrade-2024-01-15",
+  description="Before apt dist-upgrade",
+  vmstate=false
+)
+```
+
+### Naming conventions
+
+Use descriptive, dated names:
+- `pre-upgrade-YYYY-MM-DD` -- before OS or package upgrades.
+- `before-network-change` -- before network reconfiguration.
+- `baseline-v1` -- after initial setup is complete and verified.
+- `pre-migration` -- before moving a service to a different VM.
+
+Avoid: `snap1`, `test`, `backup`, or any name that doesn't explain what it protects against.
+
+### With or without RAM state
+
+| vmstate | Behavior | Use case |
+|---------|----------|----------|
+| `false` | Disk-only snapshot. On rollback, VM boots fresh from this disk state. | Default. Good for most cases. |
+| `true` | Includes RAM contents. On rollback, VM resumes from the exact point. | When you need to preserve in-memory state (e.g., active database transactions). |
+
+RAM-state snapshots are larger and only available for QEMU VMs (not LXC).
+
+## Listing snapshots
+
+```
+proxmox.vm.snapshot.list (host=<PVE_HOST>, vmid=<VMID>)
+```
+
+Output shows: name, description, creation time, whether RAM state is included, and parent snapshot.
+
+Snapshots form a tree. Each snapshot has a parent (except the first). The `current` entry represents the live state.
+
+## Rolling back to a snapshot
+
+**This is destructive.** All changes since the snapshot will be lost.
+
+1. **List snapshots to verify the target:**
+   ```
+   proxmox.vm.snapshot.list (host=<PVE_HOST>, vmid=<VMID>)
+   ```
+
+2. **Preview the rollback:**
+   ```
+   proxmox.vm.snapshot.rollback (
+     host=<PVE_HOST>,
+     vmid=<VMID>,
+     snapname="pre-upgrade-2024-01-15",
+     dry_run=true
+   )
+   ```
+
+3. **Stop the VM first** (recommended for reliable rollback):
+   ```
+   proxmox.vm.stop (host=<PVE_HOST>, vmid=<VMID>)
+   ```
+
+4. **Execute the rollback** (requires confirmation):
+   ```
+   proxmox.vm.snapshot.rollback (
+     host=<PVE_HOST>,
+     vmid=<VMID>,
+     snapname="pre-upgrade-2024-01-15"
+   )
+   confirm_operation (token=<returned_token>)
+   ```
+
+5. **Start the VM:**
+   ```
+   proxmox.vm.start (host=<PVE_HOST>, vmid=<VMID>)
+   ```
+
+## Cleaning up old snapshots
+
+Snapshots consume storage space. On LVM thin and ZFS, each snapshot holds the delta from the next snapshot in the chain. Over time, many snapshots can consume significant space.
+
+**Guidelines:**
+- Keep at most 2-3 snapshots per VM.
+- Remove snapshots older than 30 days unless they serve as a critical baseline.
+- After a successful upgrade or change, remove the "pre-" snapshot once stability is confirmed.
+
+**To remove a snapshot** (via SSH -- not yet available as an MCP tool):
+```bash
+qm delsnapshot <VMID> <SNAPNAME>       # QEMU VM
+pct delsnapshot <VMID> <SNAPNAME>       # LXC container
+```
+
+Snapshot deletion merges the snapshot data into its parent, so it may take time on large snapshots.
+
+## Snapshot vs backup
+
+| Aspect | Snapshot | Backup (vzdump) |
+|--------|----------|-----------------|
+| Speed | Instant (CoW) | Minutes to hours depending on size |
+| Location | Same storage as the VM | Can be remote (NFS, PBS) |
+| Purpose | Quick rollback point | Disaster recovery, off-host protection |
+| Retention | Short-term (days) | Long-term (weeks/months) |
+| Risk | If storage fails, snapshot is lost | Independent copy survives storage failure |
+
+Snapshots are **not backups.** They exist on the same storage as the VM. Use vzdump/PBS for real backups.
+
+## Common issues
+
+### "Can't rollback: VM is running"
+
+Stop the VM first. Some snapshot configurations (especially those without RAM state) require the VM to be stopped.
+
+### "Snapshot chain too long"
+
+Proxmox warns when the snapshot chain exceeds a certain depth. This causes performance degradation on LVM thin. Consolidate by removing intermediate snapshots.
+
+### "Not enough space for snapshot"
+
+Check `proxmox.storage.list`. Snapshots need space for future writes (CoW). If the pool is nearly full, clean up old snapshots or unused VMs first.

--- a/skills/proxmox-admin/references/storage-planning.md
+++ b/skills/proxmox-admin/references/storage-planning.md
@@ -1,0 +1,138 @@
+# Storage Planning
+
+Storage pool types, content restrictions, and capacity planning for Proxmox VE.
+
+## Checking current storage
+
+```
+proxmox.storage.list (host=<PVE_HOST>)
+```
+
+Output shows: storage name, type, status, used/total space, usage percentage, and content types.
+
+## Storage types
+
+| Type | Description | Best for | Performance |
+|------|-------------|----------|-------------|
+| `dir` | Directory on a filesystem | ISOs, templates, VZDump backups | Depends on underlying FS |
+| `lvm` | LVM logical volumes | VM disk images | Good; no thin provisioning |
+| `lvmthin` | LVM thin provisioning | VM disk images, CT rootfs | Good; supports snapshots, CoW |
+| `zfspool` | ZFS dataset | VM disk images, CT rootfs | Excellent; snapshots, compression, dedup |
+| `nfs` | NFS remote mount | Backups, ISOs, shared storage | Network-dependent |
+| `cifs` | SMB/CIFS remote mount | Backups, ISOs | Network-dependent |
+| `cephfs` / `rbd` | Ceph distributed storage | Multi-node shared VM storage | Good; requires Ceph cluster |
+| `pbs` | Proxmox Backup Server | Backups (deduplicated, incremental) | Excellent for backup workloads |
+
+## Content types
+
+Each storage pool declares which content types it can hold:
+
+| Content | Meaning | Typical pools |
+|---------|---------|---------------|
+| `images` | VM disk images (QEMU) | lvmthin, zfspool, nfs, rbd |
+| `rootdir` | CT rootfs (LXC) | lvmthin, zfspool, dir, nfs |
+| `iso` | ISO installation images | dir, nfs, cifs |
+| `vztmpl` | LXC container templates | dir, nfs, cifs |
+| `backup` | VZDump backup files | dir, nfs, cifs, pbs |
+| `snippets` | Snippets (cloud-init, hookscripts) | dir, nfs |
+
+**Key rule:** you cannot store a VM disk image on a pool that only supports `iso,vztmpl,backup`. Check the `content` field in `proxmox.storage.list` output.
+
+## Default storage layout
+
+A fresh Proxmox installation typically has:
+
+| Pool | Type | Content | Notes |
+|------|------|---------|-------|
+| `local` | dir | iso, vztmpl, backup, snippets | `/var/lib/vz` -- for ISOs and templates |
+| `local-lvm` | lvmthin | images, rootdir | Thin-provisioned LV for VM/CT disks |
+
+## Capacity planning guidelines
+
+### Warning thresholds
+
+| Usage | Action |
+|-------|--------|
+| < 70% | Healthy. No action needed. |
+| 70-85% | Monitor. Plan cleanup or expansion. |
+| 85-95% | Warning. Clean up old snapshots, unused VMs, orphaned disks. |
+| > 95% | Critical. Proxmox may refuse to create new VMs. Immediate cleanup required. |
+
+### LVM thin overcommit
+
+LVM thin pools report "virtual" size vs "actual" usage. A 100 GB thin pool can hold VMs with 200 GB of allocated disk space if they haven't written that much data. But once actual writes exceed pool capacity, the pool enters a degraded state.
+
+Check actual thin pool usage via SSH:
+```bash
+lvs -o lv_name,lv_size,data_percent,pool_lv
+```
+
+### ZFS-specific
+
+ZFS reports usage differently. Check with:
+```bash
+zfs list -o name,used,avail,refer,mountpoint
+zfs list -t snapshot -o name,used,refer    # Snapshot space usage
+```
+
+ZFS snapshots can consume significant space when the original data is modified frequently.
+
+## Storage selection for new VMs
+
+**Decision matrix:**
+
+| Requirement | Recommended pool type |
+|-------------|----------------------|
+| Fast OS disk | lvmthin (SSD) or zfspool (SSD/NVMe) |
+| VM with snapshots needed | lvmthin or zfspool (both support CoW snapshots) |
+| Bulk data / media | NFS or CIFS mount (e.g., from TrueNAS) |
+| Shared across cluster nodes | rbd (Ceph) or NFS |
+| Backup target | dir on separate disk, NFS, or PBS |
+
+## Adding a new storage pool
+
+Storage pool management is not available through the MCP tools. Use the Proxmox web UI or SSH:
+
+```bash
+# Add an NFS storage:
+pvesm add nfs backup-nfs \
+  --server 10.0.1.50 \
+  --export /mnt/backups \
+  --content backup
+
+# Add a ZFS pool:
+pvesm add zfspool fast-ssd \
+  --pool rpool/data \
+  --content images,rootdir
+
+# Add a directory:
+pvesm add dir iso-store \
+  --path /mnt/iso \
+  --content iso,vztmpl
+```
+
+## Cleaning up storage
+
+### Find orphaned disk images (via SSH)
+
+```bash
+# List all disk images in a storage pool:
+pvesm list local-lvm
+
+# Compare against running VM configs:
+qm list
+pct list
+
+# Remove an unused disk:
+pvesm free local-lvm:vm-999-disk-0
+```
+
+### Remove old backups
+
+```bash
+# List backups:
+ls /var/lib/vz/dump/
+
+# Remove specific backup:
+rm /var/lib/vz/dump/vzdump-qemu-100-*.vma.zst
+```

--- a/skills/proxmox-admin/references/vm-lifecycle.md
+++ b/skills/proxmox-admin/references/vm-lifecycle.md
@@ -45,7 +45,7 @@ Use this when no suitable template exists.
 5. **Execute the creation** (will require confirmation):
    ```
    proxmox.vm.create (...same params, dry_run=false)
-   confirm_operation (token=<returned_token>)
+   confirm_operation (token=<returned_token>, tool_name="proxmox.vm.create")
    ```
 
 6. **Start the VM:**
@@ -132,7 +132,7 @@ Set `full=true` for full clone (default), `full=false` for linked clone.
 ```
 proxmox.vm.stop (host=<PVE_HOST>, vmid=<VMID>, dry_run=true)
 proxmox.vm.stop (host=<PVE_HOST>, vmid=<VMID>)
-confirm_operation (token=<returned_token>)
+confirm_operation (token=<returned_token>, tool_name="proxmox.vm.stop")
 ```
 
 This performs a graceful shutdown (ACPI shutdown signal for QEMU, `shutdown` for LXC). The VM's guest OS should handle the signal and shut down cleanly.
@@ -153,7 +153,7 @@ pct stop <VMID>   # Force-stop LXC container
 proxmox.vm.status (host=<PVE_HOST>, vmid=<VMID>)   # Confirm stopped
 proxmox.vm.delete (host=<PVE_HOST>, vmid=<VMID>, purge=true, dry_run=true)
 proxmox.vm.delete (host=<PVE_HOST>, vmid=<VMID>, purge=true)
-confirm_operation (token=<returned_token>)
+confirm_operation (token=<returned_token>, tool_name="proxmox.vm.delete")
 ```
 
 The `purge=true` option also removes unreferenced disk images and purges the VM from backup jobs and replication configs.

--- a/skills/proxmox-admin/references/vm-lifecycle.md
+++ b/skills/proxmox-admin/references/vm-lifecycle.md
@@ -26,17 +26,17 @@ Use this when no suitable template exists.
 
 4. **Preview the creation:**
    ```
-   proxmox.vm.create (
-     host=<PVE_HOST>,
-     vmid=<VMID>,
-     vm_type="qemu",
-     name="my-new-vm",
-     cores=2,
-     memory=2048,
-     ostype="l26",
-     iso="local:iso/ubuntu-24.04.iso",
-     storage="local-lvm",
-     disk_size="32G",
+    proxmox.vm.create (
+      host=<PVE_HOST>,
+      vmid=<VMID>,
+      vm_type="qemu",
+      name="my-new-vm",
+      cores=2,
+      memory=2048,
+      os_type="l26",
+      iso="local:iso/ubuntu-24.04.iso",
+      storage="local-lvm",
+      disk_size="32G",
      net="virtio,bridge=vmbr0",
      dry_run=true
    )
@@ -64,22 +64,22 @@ Use this when no suitable template exists.
 
 2. **Create the container:**
    ```
-   proxmox.vm.create (
-     host=<PVE_HOST>,
-     vmid=<VMID>,
-     vm_type="lxc",
-     name="my-container",
-     cores=1,
-     memory=512,
-     ostype="local:vztmpl/ubuntu-24.04-standard_24.04-1_amd64.tar.zst",
-     storage="local-lvm",
-     disk_size="8",
-     net="name=eth0,bridge=vmbr0,ip=dhcp",
-     dry_run=true
-   )
-   ```
+    proxmox.vm.create (
+      host=<PVE_HOST>,
+      vmid=<VMID>,
+      vm_type="lxc",
+      name="my-container",
+      cores=1,
+      memory=512,
+      template="local:vztmpl/ubuntu-24.04-standard_24.04-1_amd64.tar.zst",
+      storage="local-lvm",
+      disk_size="8",
+      net="name=eth0,bridge=vmbr0,ip=dhcp",
+      dry_run=true
+    )
+    ```
 
-   Note: for LXC, `ostype` is the OS template path (not an ISO), `disk_size` is in GB (no suffix), and `net` uses LXC-specific format.
+    Note: for QEMU, use `os_type` for the kernel/guest OS identifier. For LXC, use `template` for the OS template path (not an ISO). `disk_size` is in GB (no suffix), and `net` uses LXC-specific format.
 
 3. Execute, start, and verify as above.
 

--- a/skills/proxmox-admin/references/vm-lifecycle.md
+++ b/skills/proxmox-admin/references/vm-lifecycle.md
@@ -1,0 +1,177 @@
+# VM/CT Lifecycle
+
+Step-by-step procedures for creating, cloning, starting, stopping, and deleting Proxmox VMs and LXC containers using Spacebot MCP tools.
+
+## Creating a QEMU VM from scratch
+
+Use this when no suitable template exists.
+
+1. **Check capacity:**
+   ```
+   proxmox.node.status (host=<PVE_HOST>)
+   ```
+   Verify sufficient RAM and CPU.
+
+2. **Check storage:**
+   ```
+   proxmox.storage.list (host=<PVE_HOST>)
+   ```
+   Identify a pool with `images` in its content field and enough free space.
+
+3. **Check existing VMIDs:**
+   ```
+   proxmox.vm.list (host=<PVE_HOST>)
+   ```
+   Choose a VMID that fits the user's numbering convention.
+
+4. **Preview the creation:**
+   ```
+   proxmox.vm.create (
+     host=<PVE_HOST>,
+     vmid=<VMID>,
+     vm_type="qemu",
+     name="my-new-vm",
+     cores=2,
+     memory=2048,
+     ostype="l26",
+     iso="local:iso/ubuntu-24.04.iso",
+     storage="local-lvm",
+     disk_size="32G",
+     net="virtio,bridge=vmbr0",
+     dry_run=true
+   )
+   ```
+
+5. **Execute the creation** (will require confirmation):
+   ```
+   proxmox.vm.create (...same params, dry_run=false)
+   confirm_operation (token=<returned_token>)
+   ```
+
+6. **Start the VM:**
+   ```
+   proxmox.vm.start (host=<PVE_HOST>, vmid=<VMID>)
+   ```
+
+7. **Verify:**
+   ```
+   proxmox.vm.status (host=<PVE_HOST>, vmid=<VMID>)
+   ```
+
+## Creating an LXC container from scratch
+
+1. Follow steps 1-3 above.
+
+2. **Create the container:**
+   ```
+   proxmox.vm.create (
+     host=<PVE_HOST>,
+     vmid=<VMID>,
+     vm_type="lxc",
+     name="my-container",
+     cores=1,
+     memory=512,
+     ostype="local:vztmpl/ubuntu-24.04-standard_24.04-1_amd64.tar.zst",
+     storage="local-lvm",
+     disk_size="8",
+     net="name=eth0,bridge=vmbr0,ip=dhcp",
+     dry_run=true
+   )
+   ```
+
+   Note: for LXC, `ostype` is the OS template path (not an ISO), `disk_size` is in GB (no suffix), and `net` uses LXC-specific format.
+
+3. Execute, start, and verify as above.
+
+## Cloning from a template
+
+This is the preferred provisioning path.
+
+1. **Identify the template:**
+   ```
+   proxmox.vm.list (host=<PVE_HOST>)
+   ```
+   Look for template VMIDs (commonly in the 9000+ range).
+
+2. **Preview the clone:**
+   ```
+   proxmox.vm.clone (
+     host=<PVE_HOST>,
+     vmid=<TEMPLATE_VMID>,
+     name="new-service-vm",
+     full=true,
+     dry_run=true
+   )
+   ```
+
+3. **Execute the clone:**
+   ```
+   proxmox.vm.clone (...same params, dry_run=false)
+   ```
+   The API will auto-assign a VMID. To specify one, add `newid=<VMID>`.
+
+4. **Start and verify:**
+   ```
+   proxmox.vm.start (host=<PVE_HOST>, vmid=<NEW_VMID>)
+   proxmox.vm.status (host=<PVE_HOST>, vmid=<NEW_VMID>)
+   ```
+
+## Full clone vs linked clone
+
+| Aspect | Full Clone | Linked Clone |
+|--------|-----------|--------------|
+| Speed | Slow (copies all disk data) | Fast (CoW snapshot) |
+| Storage | Independent, uses full disk space | Minimal initial, grows with writes |
+| Template dependency | None -- safe to delete template | Depends on template disk |
+| Use case | Production, long-lived VMs | Dev/test, ephemeral workloads |
+
+Set `full=true` for full clone (default), `full=false` for linked clone.
+
+## Stopping a VM/CT
+
+```
+proxmox.vm.stop (host=<PVE_HOST>, vmid=<VMID>, dry_run=true)
+proxmox.vm.stop (host=<PVE_HOST>, vmid=<VMID>)
+confirm_operation (token=<returned_token>)
+```
+
+This performs a graceful shutdown (ACPI shutdown signal for QEMU, `shutdown` for LXC). The VM's guest OS should handle the signal and shut down cleanly.
+
+If the VM doesn't respond to graceful shutdown (hung guest), use SSH to force-stop:
+```bash
+qm stop <VMID>   # Force-stop QEMU VM
+pct stop <VMID>   # Force-stop LXC container
+```
+
+## Deleting a VM/CT
+
+**Prerequisites:**
+- VM must be stopped.
+- Verify no linked clones depend on this VM (if it was used as a template source).
+
+```
+proxmox.vm.status (host=<PVE_HOST>, vmid=<VMID>)   # Confirm stopped
+proxmox.vm.delete (host=<PVE_HOST>, vmid=<VMID>, purge=true, dry_run=true)
+proxmox.vm.delete (host=<PVE_HOST>, vmid=<VMID>, purge=true)
+confirm_operation (token=<returned_token>)
+```
+
+The `purge=true` option also removes unreferenced disk images and purges the VM from backup jobs and replication configs.
+
+## Converting a VM to a template
+
+Templates cannot be created through the Proxmox API. Use SSH:
+
+```bash
+# Prepare the VM (run inside the guest):
+sudo cloud-init clean
+sudo truncate -s 0 /etc/machine-id
+sudo rm -f /etc/ssh/ssh_host_*
+sudo history -c
+
+# On the Proxmox host:
+qm shutdown <VMID>
+qm template <VMID>
+```
+
+After conversion, the VM icon changes and it can only be cloned, not started.

--- a/skills/proxmox-admin/references/vm-lifecycle.md
+++ b/skills/proxmox-admin/references/vm-lifecycle.md
@@ -129,15 +129,15 @@ Set `full=true` for full clone (default), `full=false` for linked clone.
 
 ## Stopping a VM/CT
 
-```
+```text
 proxmox.vm.stop (host=<PVE_HOST>, vmid=<VMID>, dry_run=true)
 proxmox.vm.stop (host=<PVE_HOST>, vmid=<VMID>)
 confirm_operation (token=<returned_token>, tool_name="proxmox.vm.stop")
 ```
 
-This performs a graceful shutdown (ACPI shutdown signal for QEMU, `shutdown` for LXC). The VM's guest OS should handle the signal and shut down cleanly.
+`proxmox.vm.stop` performs an immediate force-stop. The `dry_run=true` call previews that same force-stop without executing it. This does not send an ACPI or graceful shutdown signal; it halts the QEMU VM or LXC container immediately once confirmed.
 
-If the VM doesn't respond to graceful shutdown (hung guest), use SSH to force-stop:
+If you need to verify the equivalent host-level commands over SSH, they are the same class of force-stop operation:
 ```bash
 qm stop <VMID>   # Force-stop QEMU VM
 pct stop <VMID>   # Force-stop LXC container

--- a/src/config.rs
+++ b/src/config.rs
@@ -425,6 +425,7 @@ impl Config {
             }
 
             host.token_secret = resolve_env_var(&host.token_secret);
+            host.token_secret = host.token_secret.trim().to_string();
             if host.token_secret.is_empty() || is_unresolved_env_var_reference(&host.token_secret) {
                 return Err(anyhow!(
                     "Proxmox host '{}' token_secret cannot be empty",
@@ -811,6 +812,27 @@ mod tests {
             url = "https://192.168.1.10:8006"
             token_id = "root@pam!test"
             token_secret = "${SPACEBOT_TEST_MISSING_PVE_SECRET}"
+        "#;
+
+        let mut config: Config = toml::from_str(toml_str).unwrap();
+        let result = config.validate();
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("token_secret cannot be empty")
+        );
+    }
+
+    #[test]
+    fn test_proxmox_config_rejects_whitespace_token_secret() {
+        let toml_str = r#"
+            [proxmox.hosts.bad]
+            url = "https://192.168.1.10:8006"
+            token_id = "root@pam!test"
+            token_secret = "   "
         "#;
 
         let mut config: Config = toml::from_str(toml_str).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,8 @@ pub struct Config {
     #[serde(default)]
     pub ssh: SshConfig,
     #[serde(default)]
+    pub proxmox: ProxmoxConfig,
+    #[serde(default)]
     pub audit: AuditConfig,
     #[serde(default)]
     pub rate_limits: RateLimitConfig,
@@ -256,6 +258,49 @@ fn default_metrics_listen() -> String {
     "127.0.0.1:9090".to_string()
 }
 
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ProxmoxConfig {
+    #[serde(default)]
+    pub hosts: HashMap<String, ProxmoxHost>,
+}
+
+impl ProxmoxConfig {
+    pub fn len(&self) -> usize {
+        self.hosts.len()
+    }
+}
+
+#[derive(Clone, Deserialize)]
+pub struct ProxmoxHost {
+    /// Proxmox VE API URL (e.g., "https://192.168.1.10:8006")
+    pub url: String,
+    /// API token user + token name (e.g., "root@pam!spacebot")
+    pub token_id: String,
+    /// API token secret
+    pub token_secret: String,
+    /// Node name for this host (e.g., "pve1"). If omitted, auto-detected from /nodes.
+    pub node: Option<String>,
+    /// Accept self-signed TLS certificates (default: false for homelab use).
+    #[serde(default = "default_verify_tls_false")]
+    pub verify_tls: bool,
+}
+
+fn default_verify_tls_false() -> bool {
+    false
+}
+
+impl std::fmt::Debug for ProxmoxHost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProxmoxHost")
+            .field("url", &self.url)
+            .field("token_id", &self.token_id)
+            .field("token_secret", &"<redacted>")
+            .field("node", &self.node)
+            .field("verify_tls", &self.verify_tls)
+            .finish()
+    }
+}
+
 impl Config {
     /// Load configuration from a TOML file.
     pub fn load(path: Option<PathBuf>) -> Result<Self> {
@@ -282,9 +327,10 @@ impl Config {
         config.validate()?;
 
         info!(
-            "Configuration loaded successfully: {} Docker hosts, {} SSH hosts",
+            "Configuration loaded successfully: {} Docker hosts, {} SSH hosts, {} Proxmox hosts",
             config.docker.hosts.len(),
-            config.ssh.hosts.len()
+            config.ssh.hosts.len(),
+            config.proxmox.hosts.len()
         );
 
         Ok(config)
@@ -342,6 +388,27 @@ impl Config {
             // Resolve env var references in passphrase (e.g. "$SSH_KEY_PASS" or "${SSH_KEY_PASS}")
             if let Some(passphrase) = &host.private_key_passphrase {
                 host.private_key_passphrase = Some(resolve_env_var(passphrase));
+            }
+        }
+
+        for (name, host) in &mut self.proxmox.hosts {
+            if !host.url.starts_with("https://") && !host.url.starts_with("http://") {
+                return Err(anyhow!(
+                    "Proxmox host '{}' URL must start with https:// or http://. Got: '{}'",
+                    name,
+                    host.url
+                ));
+            }
+            if host.token_id.is_empty() {
+                return Err(anyhow!("Proxmox host '{}' token_id cannot be empty", name));
+            }
+
+            host.token_secret = resolve_env_var(&host.token_secret);
+            if host.token_secret.is_empty() {
+                return Err(anyhow!(
+                    "Proxmox host '{}' token_secret cannot be empty",
+                    name
+                ));
             }
         }
 
@@ -640,5 +707,24 @@ mod tests {
         std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o600)).unwrap();
         let result = check_config_permissions(tmp.path());
         assert!(result.is_ok(), "0600 should be accepted, got: {:?}", result);
+    }
+
+    #[test]
+    fn test_proxmox_config_validation() {
+        let toml_str = r#"
+            [proxmox.hosts.bad]
+            url = "not-a-url"
+            token_id = "root@pam!test"
+            token_secret = "fake-uuid"
+        "#;
+        let mut config: Config = toml::from_str(toml_str).unwrap();
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("URL must start with")
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -280,6 +280,12 @@ pub struct ProxmoxHost {
     /// Local wait budget for async Proxmox tasks before returning the task UPID.
     #[serde(default = "default_proxmox_task_wait_timeout_secs")]
     pub task_wait_timeout_secs: u64,
+    /// Retry count for auto-assigned VMID conflicts when /cluster/nextid races.
+    #[serde(default = "default_proxmox_next_vmid_retry_attempts")]
+    pub next_vmid_retry_attempts: usize,
+    /// Backoff between auto-assigned VMID conflict retries.
+    #[serde(default = "default_proxmox_next_vmid_retry_backoff_ms")]
+    pub next_vmid_retry_backoff_ms: u64,
 }
 
 fn default_verify_tls_true() -> bool {
@@ -288,6 +294,14 @@ fn default_verify_tls_true() -> bool {
 
 fn default_proxmox_task_wait_timeout_secs() -> u64 {
     600
+}
+
+fn default_proxmox_next_vmid_retry_attempts() -> usize {
+    3
+}
+
+fn default_proxmox_next_vmid_retry_backoff_ms() -> u64 {
+    250
 }
 
 impl std::fmt::Debug for ProxmoxHost {
@@ -299,6 +313,11 @@ impl std::fmt::Debug for ProxmoxHost {
             .field("node", &self.node)
             .field("verify_tls", &self.verify_tls)
             .field("task_wait_timeout_secs", &self.task_wait_timeout_secs)
+            .field("next_vmid_retry_attempts", &self.next_vmid_retry_attempts)
+            .field(
+                "next_vmid_retry_backoff_ms",
+                &self.next_vmid_retry_backoff_ms,
+            )
             .finish()
     }
 }
@@ -674,6 +693,8 @@ mod tests {
 
         assert!(host.verify_tls);
         assert_eq!(host.task_wait_timeout_secs, 600);
+        assert_eq!(host.next_vmid_retry_attempts, 3);
+        assert_eq!(host.next_vmid_retry_backoff_ms, 250);
     }
 
     #[test]
@@ -752,10 +773,12 @@ mod tests {
         let mut config: Config = toml::from_str(toml_str).unwrap();
         let result = config.validate();
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("URL must start with"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("URL must start with")
+        );
     }
 
     #[test]
@@ -771,10 +794,12 @@ mod tests {
         let result = config.validate();
 
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("must start with https://"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("must start with https://")
+        );
     }
 
     #[test]
@@ -792,9 +817,11 @@ mod tests {
         let result = config.validate();
 
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("token_secret cannot be empty"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("token_secret cannot be empty")
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -264,12 +264,6 @@ pub struct ProxmoxConfig {
     pub hosts: HashMap<String, ProxmoxHost>,
 }
 
-impl ProxmoxConfig {
-    pub fn len(&self) -> usize {
-        self.hosts.len()
-    }
-}
-
 #[derive(Clone, Deserialize)]
 pub struct ProxmoxHost {
     /// Proxmox VE API URL (e.g., "https://192.168.1.10:8006")
@@ -280,13 +274,20 @@ pub struct ProxmoxHost {
     pub token_secret: String,
     /// Node name for this host (e.g., "pve1"). If omitted, auto-detected from /nodes.
     pub node: Option<String>,
-    /// Accept self-signed TLS certificates (default: false for homelab use).
-    #[serde(default = "default_verify_tls_false")]
+    /// Verify TLS certificates (default: true). Set to false only for trusted self-signed certs.
+    #[serde(default = "default_verify_tls_true")]
     pub verify_tls: bool,
+    /// Local wait budget for async Proxmox tasks before returning the task UPID.
+    #[serde(default = "default_proxmox_task_wait_timeout_secs")]
+    pub task_wait_timeout_secs: u64,
 }
 
-fn default_verify_tls_false() -> bool {
-    false
+fn default_verify_tls_true() -> bool {
+    true
+}
+
+fn default_proxmox_task_wait_timeout_secs() -> u64 {
+    600
 }
 
 impl std::fmt::Debug for ProxmoxHost {
@@ -297,6 +298,7 @@ impl std::fmt::Debug for ProxmoxHost {
             .field("token_secret", &"<redacted>")
             .field("node", &self.node)
             .field("verify_tls", &self.verify_tls)
+            .field("task_wait_timeout_secs", &self.task_wait_timeout_secs)
             .finish()
     }
 }
@@ -392,9 +394,9 @@ impl Config {
         }
 
         for (name, host) in &mut self.proxmox.hosts {
-            if !host.url.starts_with("https://") && !host.url.starts_with("http://") {
+            if !host.url.starts_with("https://") {
                 return Err(anyhow!(
-                    "Proxmox host '{}' URL must start with https:// or http://. Got: '{}'",
+                    "Proxmox host '{}' URL must start with https://. Got: '{}'",
                     name,
                     host.url
                 ));
@@ -404,7 +406,7 @@ impl Config {
             }
 
             host.token_secret = resolve_env_var(&host.token_secret);
-            if host.token_secret.is_empty() {
+            if host.token_secret.is_empty() || is_unresolved_env_var_reference(&host.token_secret) {
                 return Err(anyhow!(
                     "Proxmox host '{}' token_secret cannot be empty",
                     name
@@ -506,6 +508,21 @@ fn resolve_env_var(value: &str) -> String {
     }
 
     value.to_string()
+}
+
+fn is_unresolved_env_var_reference(value: &str) -> bool {
+    let trimmed = value.trim();
+
+    trimmed
+        .strip_prefix("${")
+        .and_then(|rest| rest.strip_suffix('}'))
+        .is_some_and(|var_name| !var_name.is_empty())
+        || trimmed.strip_prefix('$').is_some_and(|var_name| {
+            !var_name.is_empty()
+                && var_name
+                    .chars()
+                    .all(|character| character.is_ascii_alphanumeric() || character == '_')
+        })
 }
 
 /// Validate config file permissions are not too open (Layer 1 security).
@@ -645,6 +662,21 @@ mod tests {
     }
 
     #[test]
+    fn test_proxmox_host_verify_tls_defaults_to_true() {
+        let host: ProxmoxHost = toml::from_str(
+            r#"
+            url = "https://192.168.1.10:8006"
+            token_id = "root@pam!spacebot"
+            token_secret = "fake-uuid"
+        "#,
+        )
+        .unwrap();
+
+        assert!(host.verify_tls);
+        assert_eq!(host.task_wait_timeout_secs, 600);
+    }
+
+    #[test]
     fn test_expand_home_expands_tilde_using_home() {
         let _guard = ENV_LOCK.lock().unwrap();
         let home = std::env::temp_dir().join("spacebot-home-test");
@@ -720,11 +752,49 @@ mod tests {
         let mut config: Config = toml::from_str(toml_str).unwrap();
         let result = config.validate();
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("URL must start with")
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("URL must start with"));
+    }
+
+    #[test]
+    fn test_proxmox_config_rejects_http_url() {
+        let toml_str = r#"
+            [proxmox.hosts.bad]
+            url = "http://192.168.1.10:8006"
+            token_id = "root@pam!test"
+            token_secret = "fake-uuid"
+        "#;
+
+        let mut config: Config = toml::from_str(toml_str).unwrap();
+        let result = config.validate();
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("must start with https://"));
+    }
+
+    #[test]
+    fn test_proxmox_config_rejects_unresolved_token_secret_env_var() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _env = set_env_vars(&[("SPACEBOT_TEST_MISSING_PVE_SECRET", None)]);
+        let toml_str = r#"
+            [proxmox.hosts.bad]
+            url = "https://192.168.1.10:8006"
+            token_id = "root@pam!test"
+            token_secret = "${SPACEBOT_TEST_MISSING_PVE_SECRET}"
+        "#;
+
+        let mut config: Config = toml::from_str(toml_str).unwrap();
+        let result = config.validate();
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("token_secret cannot be empty"));
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -8,13 +8,14 @@ use tokio::sync::{Mutex, Notify};
 use tokio::time::{Duration, interval, sleep, timeout};
 use tracing::{debug, info, warn};
 
-use crate::config::{Config, DockerHost, SshHost, SshPoolConfig};
+use crate::config::{Config, DockerHost, ProxmoxHost, SshHost, SshPoolConfig};
 
-/// Manages persistent connections to Docker daemons and SSH hosts.
+/// Manages persistent connections to Docker daemons, SSH hosts, and Proxmox VE hosts.
 pub struct ConnectionManager {
     pub config: Arc<Config>,
     docker_clients: DashMap<String, DockerClient>,
     ssh_pools: DashMap<String, SshPool>,
+    proxmox_clients: DashMap<String, ProxmoxClient>,
     health: DashMap<String, ConnectionHealth>,
     metrics: Option<Arc<crate::metrics::Metrics>>,
 }
@@ -205,6 +206,206 @@ impl DockerClient {
             }
             DockerTransport::NamedPipe { path } => format!("named pipe {}", path),
         }
+    }
+}
+
+/// Proxmox VE API client wrapper.
+#[derive(Clone)]
+pub struct ProxmoxClient {
+    client: reqwest::Client,
+    base_url: String,
+    auth_header: String,
+    node: Option<String>,
+}
+
+impl ProxmoxClient {
+    pub fn new(host: &ProxmoxHost) -> Result<Self> {
+        let client = reqwest::Client::builder()
+            .danger_accept_invalid_certs(!host.verify_tls)
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|error| anyhow!("Failed to build Proxmox HTTP client: {}", error))?;
+
+        let base_url = host.url.trim_end_matches('/').to_string();
+        let auth_header = format!("PVEAPIToken={}={}", host.token_id, host.token_secret);
+
+        Ok(Self {
+            client,
+            base_url,
+            auth_header,
+            node: host.node.clone(),
+        })
+    }
+
+    /// GET request to the Proxmox API. Returns the `data` field from the response envelope.
+    pub async fn get(&self, path: &str) -> Result<serde_json::Value> {
+        let url = format!("{}/api2/json{}", self.base_url, path);
+        let response = self
+            .client
+            .get(&url)
+            .header("Authorization", &self.auth_header)
+            .send()
+            .await
+            .map_err(|error| anyhow!("Proxmox API request failed: {}", error))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(anyhow!(
+                "Proxmox API error (HTTP {}): {}",
+                status.as_u16(),
+                body
+            ));
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|error| anyhow!("Failed to parse Proxmox API response: {}", error))?;
+
+        Ok(body.get("data").cloned().unwrap_or(serde_json::Value::Null))
+    }
+
+    /// POST request to the Proxmox API (form-urlencoded body).
+    pub async fn post(&self, path: &str, params: &[(&str, &str)]) -> Result<serde_json::Value> {
+        let url = format!("{}/api2/json{}", self.base_url, path);
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", &self.auth_header)
+            .form(params)
+            .send()
+            .await
+            .map_err(|error| anyhow!("Proxmox API POST failed: {}", error))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(anyhow!(
+                "Proxmox API error (HTTP {}): {}",
+                status.as_u16(),
+                body
+            ));
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|error| anyhow!("Failed to parse Proxmox API response: {}", error))?;
+
+        Ok(body.get("data").cloned().unwrap_or(serde_json::Value::Null))
+    }
+
+    /// DELETE request to the Proxmox API.
+    pub async fn delete(&self, path: &str) -> Result<serde_json::Value> {
+        let url = format!("{}/api2/json{}", self.base_url, path);
+        let response = self
+            .client
+            .delete(&url)
+            .header("Authorization", &self.auth_header)
+            .send()
+            .await
+            .map_err(|error| anyhow!("Proxmox API DELETE failed: {}", error))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(anyhow!(
+                "Proxmox API error (HTTP {}): {}",
+                status.as_u16(),
+                body
+            ));
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|error| anyhow!("Failed to parse Proxmox API response: {}", error))?;
+
+        Ok(body.get("data").cloned().unwrap_or(serde_json::Value::Null))
+    }
+
+    /// Wait for a Proxmox async task (UPID) to complete.
+    pub async fn wait_for_task(
+        &self,
+        node: &str,
+        upid: &str,
+        max_wait_secs: u64,
+    ) -> Result<String> {
+        let start = Instant::now();
+        let max_duration = Duration::from_secs(max_wait_secs);
+        let poll_interval = Duration::from_secs(2);
+
+        loop {
+            let status = self
+                .get(&format!("/nodes/{}/tasks/{}/status", node, upid))
+                .await?;
+            let task_status = status
+                .get("status")
+                .and_then(|value| value.as_str())
+                .unwrap_or("unknown");
+
+            if task_status == "stopped" {
+                let exit_status = status
+                    .get("exitstatus")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("unknown");
+                if exit_status == "OK" {
+                    return Ok(format!("Task completed successfully (UPID: {})", upid));
+                }
+
+                return Err(anyhow!(
+                    "Proxmox task failed with exit status '{}' (UPID: {})",
+                    exit_status,
+                    upid
+                ));
+            }
+
+            if start.elapsed() > max_duration {
+                return Err(anyhow!(
+                    "Proxmox task timed out after {}s (UPID: {}). Task may still be running.",
+                    max_wait_secs,
+                    upid
+                ));
+            }
+
+            sleep(poll_interval).await;
+        }
+    }
+
+    /// Validate connectivity by calling GET /version.
+    pub async fn validate(&self) -> Result<()> {
+        self.get("/version").await?;
+        Ok(())
+    }
+
+    /// Get the configured node name, or auto-detect the first node from the cluster.
+    pub async fn resolve_node(&self, override_node: Option<&str>) -> Result<String> {
+        if let Some(node) = override_node {
+            return Ok(node.to_string());
+        }
+        if let Some(node) = &self.node {
+            return Ok(node.clone());
+        }
+
+        let nodes = self.get("/nodes").await?;
+        nodes
+            .as_array()
+            .and_then(|items| items.first())
+            .and_then(|node| node.get("node"))
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string())
+            .ok_or_else(|| {
+                anyhow!("Could not auto-detect Proxmox node name. Set 'node' in config.")
+            })
+    }
+
+    pub fn connection_summary(&self) -> String {
+        format!(
+            "{} (node: {})",
+            self.base_url,
+            self.node.as_deref().unwrap_or("auto")
+        )
     }
 }
 
@@ -628,6 +829,7 @@ impl ConnectionManager {
             config: Arc::new(config),
             docker_clients: DashMap::new(),
             ssh_pools: DashMap::new(),
+            proxmox_clients: DashMap::new(),
             health: DashMap::new(),
             metrics,
         };
@@ -703,10 +905,58 @@ impl ConnectionManager {
             info!("SSH pool '{}' initialized (connectivity pending)", name);
         }
 
+        for (name, host) in &manager.config.proxmox.hosts {
+            let health_key = format!("proxmox:{}", name);
+            manager.health.insert(
+                health_key.clone(),
+                ConnectionHealth {
+                    status: ConnectionStatus::Connecting,
+                    last_success: None,
+                    last_error: None,
+                    consecutive_failures: 0,
+                    skip_cycles: 0,
+                    cycles_skipped: 0,
+                },
+            );
+
+            match ProxmoxClient::new(host) {
+                Ok(client) => {
+                    let validate_result = client.validate().await;
+                    manager.proxmox_clients.insert(name.clone(), client.clone());
+
+                    match validate_result {
+                        Ok(()) => {
+                            manager.mark_healthy(&health_key);
+                            info!(
+                                "Proxmox '{}' connected via {}",
+                                name,
+                                client.connection_summary()
+                            );
+                        }
+                        Err(error) => {
+                            manager.mark_unhealthy(&health_key, error.to_string());
+                            warn!(
+                                "Proxmox '{}' API check failed during startup (will retry): {}",
+                                name, error
+                            );
+                        }
+                    }
+                }
+                Err(error) => {
+                    manager.mark_unhealthy(&health_key, error.to_string());
+                    warn!(
+                        "Failed to initialize Proxmox client for '{}': {}",
+                        name, error
+                    );
+                }
+            }
+        }
+
         info!(
-            "ConnectionManager initialized with {} Docker hosts and {} SSH hosts",
+            "ConnectionManager initialized with {} Docker hosts, {} SSH hosts, {} Proxmox hosts",
             manager.config.docker.hosts.len(),
-            manager.config.ssh.hosts.len()
+            manager.config.ssh.hosts.len(),
+            manager.config.proxmox.hosts.len()
         );
 
         Ok(manager)
@@ -728,6 +978,20 @@ impl ConnectionManager {
             .get(name)
             .map(|entry| entry.clone())
             .ok_or_else(|| anyhow!("Docker host '{}' not configured", name))
+    }
+
+    pub fn get_proxmox(&self, name: &str) -> Result<ProxmoxClient> {
+        let health_key = format!("proxmox:{}", name);
+        if let Some(health) = self.health.get(&health_key) {
+            if health.status == ConnectionStatus::Disconnected {
+                return Err(anyhow!(self.disconnected_error_message(&health_key, name)));
+            }
+        }
+
+        self.proxmox_clients
+            .get(name)
+            .map(|entry| entry.clone())
+            .ok_or_else(|| anyhow!("Proxmox host '{}' not configured", name))
     }
 
     pub async fn ssh_acquire_channel(&self, host: &str) -> Result<AcquiredChannel> {
@@ -932,6 +1196,49 @@ impl ConnectionManager {
                         metrics.ssh_pool_idle.with_label_values(&[&name]).set(idle);
                     }
                 }
+
+                let proxmox_clients: Vec<(String, ProxmoxClient)> = manager
+                    .proxmox_clients
+                    .iter()
+                    .map(|entry| (entry.key().clone(), entry.value().clone()))
+                    .collect();
+                for (name, client) in proxmox_clients {
+                    let health_key = format!("proxmox:{}", name);
+                    if manager.should_skip_health_check(&health_key) {
+                        continue;
+                    }
+
+                    match client.validate().await {
+                        Ok(()) => {
+                            if manager.mark_healthy(&health_key) {
+                                info!("Proxmox '{}' recovered", name);
+                            }
+                        }
+                        Err(error) => {
+                            let failures = manager.mark_unhealthy(&health_key, error.to_string());
+                            warn!(
+                                "Proxmox '{}' unhealthy ({} consecutive failures): {}",
+                                name, failures, error
+                            );
+                        }
+                    }
+                    if let Some(ref metrics) = manager.metrics {
+                        let value = if manager
+                            .health
+                            .get(&health_key)
+                            .map(|health| health.status == ConnectionStatus::Connected)
+                            .unwrap_or(false)
+                        {
+                            1
+                        } else {
+                            0
+                        };
+                        metrics
+                            .proxmox_health
+                            .with_label_values(&[&name])
+                            .set(value);
+                    }
+                }
             }
         })
     }
@@ -992,6 +1299,7 @@ mod tests {
             config: Arc::new(Config {
                 docker: Default::default(),
                 ssh: Default::default(),
+                proxmox: Default::default(),
                 audit: Default::default(),
                 rate_limits: Default::default(),
                 tools: Default::default(),
@@ -1000,6 +1308,7 @@ mod tests {
             }),
             docker_clients: DashMap::new(),
             ssh_pools: DashMap::new(),
+            proxmox_clients: DashMap::new(),
             health: DashMap::new(),
             metrics: None,
         };

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -362,10 +362,9 @@ impl ProxmoxClient {
             }
 
             if start.elapsed() > max_duration {
-                return Err(anyhow!(
-                    "Proxmox task timed out after {}s (UPID: {}). Task may still be running.",
-                    max_wait_secs,
-                    upid
+                return Ok(format!(
+                    "Proxmox task is still running after the local wait budget of {}s (UPID: {}). Poll task status in Proxmox to continue tracking it.",
+                    max_wait_secs, upid
                 ));
             }
 
@@ -389,15 +388,7 @@ impl ProxmoxClient {
         }
 
         let nodes = self.get("/nodes").await?;
-        nodes
-            .as_array()
-            .and_then(|items| items.first())
-            .and_then(|node| node.get("node"))
-            .and_then(|value| value.as_str())
-            .map(|value| value.to_string())
-            .ok_or_else(|| {
-                anyhow!("Could not auto-detect Proxmox node name. Set 'node' in config.")
-            })
+        auto_detect_single_node_name(&nodes)
     }
 
     pub fn connection_summary(&self) -> String {
@@ -407,6 +398,38 @@ impl ProxmoxClient {
             self.node.as_deref().unwrap_or("auto")
         )
     }
+}
+
+fn auto_detect_single_node_name(nodes: &serde_json::Value) -> Result<String> {
+    let items = nodes
+        .as_array()
+        .ok_or_else(|| anyhow!("Could not auto-detect Proxmox node name. Set 'node' in config."))?;
+
+    if items.is_empty() {
+        return Err(anyhow!(
+            "Could not auto-detect Proxmox node name. Set 'node' in config."
+        ));
+    }
+
+    if items.len() > 1 {
+        let mut node_names = items
+            .iter()
+            .filter_map(|node| node.get("node").and_then(|value| value.as_str()))
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        node_names.sort();
+
+        return Err(anyhow!(
+            "Multiple Proxmox nodes detected ({}). Set 'node' in config.",
+            node_names.join(", ")
+        ));
+    }
+
+    items[0]
+        .get("node")
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("Could not auto-detect Proxmox node name. Set 'node' in config."))
 }
 
 /// SSH connection pool for a single host.
@@ -1328,5 +1351,29 @@ mod tests {
         let message = manager.disconnected_error_message("ssh:test", "test");
         assert!(message.contains("boom"));
         assert!(message.contains("test"));
+    }
+
+    #[test]
+    fn test_auto_detect_single_node_name_returns_only_node() {
+        let nodes = serde_json::json!([
+            { "node": "pve1" }
+        ]);
+
+        assert_eq!(auto_detect_single_node_name(&nodes).unwrap(), "pve1");
+    }
+
+    #[test]
+    fn test_auto_detect_single_node_name_rejects_multiple_nodes() {
+        let nodes = serde_json::json!([
+            { "node": "pve2" },
+            { "node": "pve1" }
+        ]);
+
+        let error = auto_detect_single_node_name(&nodes).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Multiple Proxmox nodes detected (pve1, pve2)")
+        );
     }
 }

--- a/src/health.rs
+++ b/src/health.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use tracing::warn;
 
 use crate::config::Config;
-use crate::connection::DockerClient;
+use crate::connection::{DockerClient, ProxmoxClient};
 
 /// Run diagnostics and print results to stdout.
 pub async fn run_diagnostics(config: &Config) -> Result<()> {
@@ -39,14 +39,30 @@ pub async fn run_diagnostics(config: &Config) -> Result<()> {
         }
     }
 
+    println!("\nChecking Proxmox hosts:");
+    for (name, host) in &config.proxmox.hosts {
+        match check_proxmox_connection(host).await {
+            Ok(()) => {
+                println!("  ✓ Proxmox '{}': {} -> accessible", name, host.url);
+            }
+            Err(error) => {
+                println!("  ✗ Proxmox '{}': {} -> {}", name, host.url, error);
+                println!("    -> Check that the Proxmox API is reachable on port 8006");
+                println!("    -> Verify the token_id and token_secret are correct");
+                println!("    -> Set verify_tls = false for self-signed certificates");
+            }
+        }
+    }
+
     println!("\nChecking security configuration:");
     check_security_config(config);
 
     println!("\nConfiguration summary:");
     println!(
-        "  {} Docker hosts, {} SSH hosts",
+        "  {} Docker hosts, {} SSH hosts, {} Proxmox hosts",
         config.docker.hosts.len(),
-        config.ssh.hosts.len()
+        config.ssh.hosts.len(),
+        config.proxmox.hosts.len()
     );
     println!(
         "  SSH pool: max {} sessions, {} min lifetime, {} min idle, {}s keepalive",
@@ -101,6 +117,11 @@ async fn check_ssh_connection(host: &crate::config::SshHost) -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn check_proxmox_connection(host: &crate::config::ProxmoxHost) -> Result<()> {
+    let proxmox = ProxmoxClient::new(host)?;
+    proxmox.validate().await
 }
 
 fn check_security_config(config: &Config) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ async fn run_server(config_path: Option<PathBuf>) -> Result<()> {
         "Configuration loaded: {} Docker hosts, {} SSH hosts, {} Proxmox hosts",
         config.docker.len(),
         config.ssh.hosts.len(),
-        config.proxmox.len()
+        config.proxmox.hosts.len()
     );
 
     // Create metrics if configured

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,9 +88,10 @@ async fn run_server(config_path: Option<PathBuf>) -> Result<()> {
         }
     };
     info!(
-        "Configuration loaded: {} Docker hosts, {} SSH hosts",
+        "Configuration loaded: {} Docker hosts, {} SSH hosts, {} Proxmox hosts",
         config.docker.len(),
-        config.ssh.hosts.len()
+        config.ssh.hosts.len(),
+        config.proxmox.len()
     );
 
     // Create metrics if configured

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -178,13 +178,13 @@ struct DockerImagePruneArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct ProxmoxNodeListArgs {
-    /// Proxmox host name from config (defaults to first configured host)
+    /// Proxmox host name from config. Defaults only when exactly one host is configured; multiple-host setups must pass host explicitly.
     pub host: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct ProxmoxNodeStatusArgs {
-    /// Proxmox host name from config (defaults to first configured host)
+    /// Proxmox host name from config. Defaults only when exactly one host is configured; multiple-host setups must pass host explicitly.
     pub host: Option<String>,
     /// Node name (defaults to the configured node or auto-detected)
     pub node: Option<String>,
@@ -192,7 +192,7 @@ struct ProxmoxNodeStatusArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct ProxmoxVmListArgs {
-    /// Proxmox host name from config (defaults to first configured host)
+    /// Proxmox host name from config. Defaults only when exactly one host is configured; multiple-host setups must pass host explicitly.
     pub host: Option<String>,
     /// Node name (defaults to configured or auto-detected)
     pub node: Option<String>,
@@ -202,7 +202,7 @@ struct ProxmoxVmListArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct ProxmoxVmStatusArgs {
-    /// Proxmox host name from config (defaults to first configured host)
+    /// Proxmox host name from config. Defaults only when exactly one host is configured; multiple-host setups must pass host explicitly.
     pub host: Option<String>,
     /// Node name (defaults to configured or auto-detected)
     pub node: Option<String>,
@@ -214,7 +214,7 @@ struct ProxmoxVmStatusArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct ProxmoxVmStartArgs {
-    /// Proxmox host name from config
+    /// Proxmox host name from config. Defaults only when exactly one host is configured; multiple-host setups must pass host explicitly.
     pub host: Option<String>,
     /// Node name
     pub node: Option<String>,
@@ -228,7 +228,7 @@ struct ProxmoxVmStartArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct ProxmoxVmStopArgs {
-    /// Proxmox host name from config
+    /// Proxmox host name from config. Defaults only when exactly one host is configured; multiple-host setups must pass host explicitly.
     pub host: Option<String>,
     /// Node name
     pub node: Option<String>,
@@ -242,7 +242,7 @@ struct ProxmoxVmStopArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct ProxmoxVmCreateArgs {
-    /// Proxmox host name from config
+    /// Proxmox host name from config. Defaults only when exactly one host is configured; multiple-host setups must pass host explicitly.
     pub host: Option<String>,
     /// Node name
     pub node: Option<String>,
@@ -274,7 +274,7 @@ struct ProxmoxVmCreateArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct ProxmoxVmCloneArgs {
-    /// Proxmox host name from config
+    /// Proxmox host name from config. Defaults only when exactly one host is configured; multiple-host setups must pass host explicitly.
     pub host: Option<String>,
     /// Node name
     pub node: Option<String>,
@@ -294,7 +294,7 @@ struct ProxmoxVmCloneArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct ProxmoxVmDeleteArgs {
-    /// Proxmox host name from config
+    /// Proxmox host name from config. Defaults only when exactly one host is configured; multiple-host setups must pass host explicitly.
     pub host: Option<String>,
     /// Node name
     pub node: Option<String>,
@@ -310,7 +310,7 @@ struct ProxmoxVmDeleteArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct ProxmoxSnapshotListArgs {
-    /// Proxmox host name from config
+    /// Proxmox host name from config. Defaults only when exactly one host is configured; multiple-host setups must pass host explicitly.
     pub host: Option<String>,
     /// Node name
     pub node: Option<String>,
@@ -322,7 +322,7 @@ struct ProxmoxSnapshotListArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct ProxmoxSnapshotCreateArgs {
-    /// Proxmox host name from config
+    /// Proxmox host name from config. Defaults only when exactly one host is configured; multiple-host setups must pass host explicitly.
     pub host: Option<String>,
     /// Node name
     pub node: Option<String>,
@@ -342,7 +342,7 @@ struct ProxmoxSnapshotCreateArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct ProxmoxSnapshotRollbackArgs {
-    /// Proxmox host name from config
+    /// Proxmox host name from config. Defaults only when exactly one host is configured; multiple-host setups must pass host explicitly.
     pub host: Option<String>,
     /// Node name
     pub node: Option<String>,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1455,10 +1455,14 @@ impl HomelabMcpServer {
             "proxmox.vm.stop" => {
                 let params: ProxmoxVmStopArgs = serde_json::from_str(&original_params_json)
                     .map_err(|error| error.to_string())?;
+                let host = params
+                    .host
+                    .map_or_else(|| proxmox::default_proxmox_host(&self.manager), Ok)
+                    .map_err(|error| error.to_string())?;
                 self.audit
                     .log(
                         "proxmox.vm.stop",
-                        params.host.as_deref().unwrap_or("default"),
+                        &host,
                         "confirmed_exec",
                         Some(&params.vmid.to_string()),
                     )
@@ -1466,7 +1470,7 @@ impl HomelabMcpServer {
                     .ok();
                 proxmox::vm_stop_confirmed(
                     self.manager.clone(),
-                    params.host.unwrap_or_else(|| "default".to_string()),
+                    host,
                     params.node,
                     params.vmid,
                     params.vm_type,
@@ -1478,10 +1482,14 @@ impl HomelabMcpServer {
             "proxmox.vm.create" => {
                 let params: ProxmoxVmCreateArgs = serde_json::from_str(&original_params_json)
                     .map_err(|error| error.to_string())?;
+                let host = params
+                    .host
+                    .map_or_else(|| proxmox::default_proxmox_host(&self.manager), Ok)
+                    .map_err(|error| error.to_string())?;
                 self.audit
                     .log(
                         "proxmox.vm.create",
-                        params.host.as_deref().unwrap_or("default"),
+                        &host,
                         "confirmed_exec",
                         params.name.as_deref(),
                     )
@@ -1489,7 +1497,7 @@ impl HomelabMcpServer {
                     .ok();
                 proxmox::vm_create_confirmed(
                     self.manager.clone(),
-                    params.host.unwrap_or_else(|| "default".to_string()),
+                    host,
                     params.node,
                     params.vmid,
                     params.vm_type.unwrap_or_else(|| "qemu".to_string()),
@@ -1509,10 +1517,14 @@ impl HomelabMcpServer {
             "proxmox.vm.delete" => {
                 let params: ProxmoxVmDeleteArgs = serde_json::from_str(&original_params_json)
                     .map_err(|error| error.to_string())?;
+                let host = params
+                    .host
+                    .map_or_else(|| proxmox::default_proxmox_host(&self.manager), Ok)
+                    .map_err(|error| error.to_string())?;
                 self.audit
                     .log(
                         "proxmox.vm.delete",
-                        params.host.as_deref().unwrap_or("default"),
+                        &host,
                         "confirmed_exec",
                         Some(&params.vmid.to_string()),
                     )
@@ -1520,7 +1532,7 @@ impl HomelabMcpServer {
                     .ok();
                 proxmox::vm_delete_confirmed(
                     self.manager.clone(),
-                    params.host.unwrap_or_else(|| "default".to_string()),
+                    host,
                     params.node,
                     params.vmid,
                     params.vm_type.unwrap_or_else(|| "qemu".to_string()),
@@ -1534,10 +1546,14 @@ impl HomelabMcpServer {
                 let params: ProxmoxSnapshotRollbackArgs =
                     serde_json::from_str(&original_params_json)
                         .map_err(|error| error.to_string())?;
+                let host = params
+                    .host
+                    .map_or_else(|| proxmox::default_proxmox_host(&self.manager), Ok)
+                    .map_err(|error| error.to_string())?;
                 self.audit
                     .log(
                         "proxmox.vm.snapshot.rollback",
-                        params.host.as_deref().unwrap_or("default"),
+                        &host,
                         "confirmed_exec",
                         Some(&params.snapname),
                     )
@@ -1545,7 +1561,7 @@ impl HomelabMcpServer {
                     .ok();
                 proxmox::snapshot_rollback_confirmed(
                     self.manager.clone(),
-                    params.host.unwrap_or_else(|| "default".to_string()),
+                    host,
                     params.node,
                     params.vmid,
                     params.vm_type.unwrap_or_else(|| "qemu".to_string()),

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -14,7 +14,7 @@ use crate::confirmation::ConfirmationManager;
 use crate::connection::ConnectionManager;
 use crate::metrics::Metrics;
 use crate::rate_limit::RateLimiter;
-use crate::tools::{docker, docker_image, ssh, verify};
+use crate::tools::{docker, docker_image, proxmox, ssh, verify};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct DockerContainerListArgs {
@@ -176,6 +176,200 @@ struct DockerImagePruneArgs {
     pub dry_run: Option<bool>,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ProxmoxNodeListArgs {
+    /// Proxmox host name from config (defaults to first configured host)
+    pub host: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ProxmoxNodeStatusArgs {
+    /// Proxmox host name from config (defaults to first configured host)
+    pub host: Option<String>,
+    /// Node name (defaults to the configured node or auto-detected)
+    pub node: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ProxmoxVmListArgs {
+    /// Proxmox host name from config (defaults to first configured host)
+    pub host: Option<String>,
+    /// Node name (defaults to configured or auto-detected)
+    pub node: Option<String>,
+    /// Filter by type: "qemu" for VMs, "lxc" for containers, omit for both
+    pub vm_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ProxmoxVmStatusArgs {
+    /// Proxmox host name from config (defaults to first configured host)
+    pub host: Option<String>,
+    /// Node name (defaults to configured or auto-detected)
+    pub node: Option<String>,
+    /// VM/CT ID number
+    pub vmid: u64,
+    /// "qemu" or "lxc" (defaults to "qemu")
+    pub vm_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ProxmoxVmStartArgs {
+    /// Proxmox host name from config
+    pub host: Option<String>,
+    /// Node name
+    pub node: Option<String>,
+    /// VM/CT ID number
+    pub vmid: u64,
+    /// "qemu" or "lxc" (defaults to "qemu")
+    pub vm_type: Option<String>,
+    /// Preview without executing
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ProxmoxVmStopArgs {
+    /// Proxmox host name from config
+    pub host: Option<String>,
+    /// Node name
+    pub node: Option<String>,
+    /// VM/CT ID number
+    pub vmid: u64,
+    /// "qemu" or "lxc" (defaults to "qemu")
+    pub vm_type: Option<String>,
+    /// Preview without executing
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ProxmoxVmCreateArgs {
+    /// Proxmox host name from config
+    pub host: Option<String>,
+    /// Node name
+    pub node: Option<String>,
+    /// VM/CT ID (auto-assigned if omitted)
+    pub vmid: Option<u64>,
+    /// "qemu" or "lxc" (defaults to "qemu")
+    pub vm_type: Option<String>,
+    /// VM/CT name
+    pub name: Option<String>,
+    /// Number of CPU cores
+    pub cores: Option<u64>,
+    /// Memory in MB
+    pub memory: Option<u64>,
+    /// OS type for QEMU (e.g. "l26" for Linux) or template path for LXC
+    pub ostype: Option<String>,
+    /// ISO image for QEMU (e.g. "local:iso/ubuntu-22.04.iso")
+    pub iso: Option<String>,
+    /// Storage pool for disk (e.g. "local-lvm")
+    pub storage: Option<String>,
+    /// Disk size (e.g. "32G" for QEMU, "8" GB for LXC)
+    pub disk_size: Option<String>,
+    /// Network config (e.g. "virtio,bridge=vmbr0" for QEMU)
+    pub net: Option<String>,
+    /// Preview without executing
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ProxmoxVmCloneArgs {
+    /// Proxmox host name from config
+    pub host: Option<String>,
+    /// Node name
+    pub node: Option<String>,
+    /// Source VM ID to clone
+    pub vmid: u64,
+    /// Target VM ID (auto-assigned if omitted)
+    pub newid: Option<u64>,
+    /// Name for the new VM
+    pub name: Option<String>,
+    /// Full clone (true) or linked clone (false). Default: true
+    pub full: Option<bool>,
+    /// Target storage for the clone
+    pub target_storage: Option<String>,
+    /// Preview without executing
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ProxmoxVmDeleteArgs {
+    /// Proxmox host name from config
+    pub host: Option<String>,
+    /// Node name
+    pub node: Option<String>,
+    /// VM/CT ID to delete
+    pub vmid: u64,
+    /// "qemu" or "lxc" (defaults to "qemu")
+    pub vm_type: Option<String>,
+    /// Also remove unreferenced disks and purge from configs
+    pub purge: Option<bool>,
+    /// Preview without executing (recommended: use dry_run=true first)
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ProxmoxSnapshotListArgs {
+    /// Proxmox host name from config
+    pub host: Option<String>,
+    /// Node name
+    pub node: Option<String>,
+    /// VM/CT ID
+    pub vmid: u64,
+    /// "qemu" or "lxc" (defaults to "qemu")
+    pub vm_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ProxmoxSnapshotCreateArgs {
+    /// Proxmox host name from config
+    pub host: Option<String>,
+    /// Node name
+    pub node: Option<String>,
+    /// VM/CT ID
+    pub vmid: u64,
+    /// "qemu" or "lxc" (defaults to "qemu")
+    pub vm_type: Option<String>,
+    /// Snapshot name (must be unique for this VM)
+    pub snapname: String,
+    /// Optional description for the snapshot
+    pub description: Option<String>,
+    /// Include VM RAM state in snapshot (QEMU only)
+    pub vmstate: Option<bool>,
+    /// Preview without executing
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ProxmoxSnapshotRollbackArgs {
+    /// Proxmox host name from config
+    pub host: Option<String>,
+    /// Node name
+    pub node: Option<String>,
+    /// VM/CT ID
+    pub vmid: u64,
+    /// "qemu" or "lxc" (defaults to "qemu")
+    pub vm_type: Option<String>,
+    /// Snapshot name to rollback to
+    pub snapname: String,
+    /// Preview without executing
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ProxmoxStorageListArgs {
+    /// Proxmox host name from config
+    pub host: Option<String>,
+    /// Node name
+    pub node: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ProxmoxNetworkListArgs {
+    /// Proxmox host name from config
+    pub host: Option<String>,
+    /// Node name
+    pub node: Option<String>,
+}
+
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for HomelabMcpServer {
     fn get_info(&self) -> ServerInfo {
@@ -185,7 +379,7 @@ impl ServerHandler for HomelabMcpServer {
                 env!("CARGO_PKG_VERSION"),
             ))
             .with_instructions(
-                "Homelab Docker and SSH tools for Spacebot.\n\n\
+                "Homelab Docker, SSH, and Proxmox VE tools for Spacebot.\n\n\
                  IMPORTANT — Tool result integrity:\n\
                  - Every tool response contains a unique server_nonce and executed_at timestamp \
                    that only this server can produce. Do NOT fabricate these fields.\n\
@@ -254,6 +448,20 @@ impl HomelabMcpServer {
         ("docker.image.inspect", "Docker"),
         ("docker.image.delete", "Docker"),
         ("docker.image.prune", "Docker"),
+        ("proxmox.node.list", "Proxmox"),
+        ("proxmox.node.status", "Proxmox"),
+        ("proxmox.vm.list", "Proxmox"),
+        ("proxmox.vm.status", "Proxmox"),
+        ("proxmox.vm.start", "Proxmox"),
+        ("proxmox.vm.stop", "Proxmox"),
+        ("proxmox.vm.create", "Proxmox"),
+        ("proxmox.vm.clone", "Proxmox"),
+        ("proxmox.vm.delete", "Proxmox"),
+        ("proxmox.vm.snapshot.list", "Proxmox"),
+        ("proxmox.vm.snapshot.create", "Proxmox"),
+        ("proxmox.vm.snapshot.rollback", "Proxmox"),
+        ("proxmox.storage.list", "Proxmox"),
+        ("proxmox.network.list", "Proxmox"),
         ("ssh.exec", "SSH"),
         ("ssh.upload", "SSH"),
         ("ssh.download", "SSH"),
@@ -290,8 +498,8 @@ impl HomelabMcpServer {
                 *counts.entry(category).or_insert(0) += 1;
             }
         }
-        // Fixed display order: Docker → SSH → Confirm → Audit
-        let order = ["Docker", "SSH", "Confirm", "Audit"];
+        // Fixed display order: Docker → SSH → Proxmox → Confirm → Audit
+        let order = ["Docker", "SSH", "Proxmox", "Confirm", "Audit"];
         order
             .iter()
             .filter_map(|cat| counts.get(cat).map(|n| format!("{cat} ({n})")))
@@ -653,6 +861,369 @@ impl HomelabMcpServer {
     }
 
     #[tool(
+        name = "proxmox.node.list",
+        description = "List Proxmox VE cluster nodes with resource usage (CPU, memory, uptime)",
+        annotations(read_only_hint = true, idempotent_hint = true)
+    )]
+    async fn proxmox_node_list(
+        &self,
+        Parameters(args): Parameters<ProxmoxNodeListArgs>,
+    ) -> Result<String, String> {
+        self.ensure_tool_available("proxmox.node.list")?;
+        let start = Instant::now();
+        let result = proxmox::node_list(self.manager.clone(), args.host, self.audit.clone())
+            .await
+            .map_err(|error| error.to_string());
+        self.record_tool_call("proxmox.node.list", start, result.is_err());
+        result
+    }
+
+    #[tool(
+        name = "proxmox.node.status",
+        description = "Get detailed Proxmox node status (CPU, memory, storage, kernel, uptime)",
+        annotations(read_only_hint = true, idempotent_hint = true)
+    )]
+    async fn proxmox_node_status(
+        &self,
+        Parameters(args): Parameters<ProxmoxNodeStatusArgs>,
+    ) -> Result<String, String> {
+        self.ensure_tool_available("proxmox.node.status")?;
+        let start = Instant::now();
+        let result = proxmox::node_status(
+            self.manager.clone(),
+            args.host,
+            args.node,
+            self.audit.clone(),
+        )
+        .await
+        .map_err(|error| error.to_string());
+        self.record_tool_call("proxmox.node.status", start, result.is_err());
+        result
+    }
+
+    #[tool(
+        name = "proxmox.vm.list",
+        description = "List VMs and LXC containers on a Proxmox node. Filter by type with vm_type='qemu' or vm_type='lxc'.",
+        annotations(read_only_hint = true, idempotent_hint = true)
+    )]
+    async fn proxmox_vm_list(
+        &self,
+        Parameters(args): Parameters<ProxmoxVmListArgs>,
+    ) -> Result<String, String> {
+        self.ensure_tool_available("proxmox.vm.list")?;
+        let start = Instant::now();
+        let result = proxmox::vm_list(
+            self.manager.clone(),
+            args.host,
+            args.node,
+            args.vm_type,
+            self.audit.clone(),
+        )
+        .await
+        .map_err(|error| error.to_string());
+        self.record_tool_call("proxmox.vm.list", start, result.is_err());
+        result
+    }
+
+    #[tool(
+        name = "proxmox.vm.status",
+        description = "Get detailed status of a specific VM or LXC container (CPU, memory, disk, network I/O)",
+        annotations(read_only_hint = true, idempotent_hint = true)
+    )]
+    async fn proxmox_vm_status(
+        &self,
+        Parameters(args): Parameters<ProxmoxVmStatusArgs>,
+    ) -> Result<String, String> {
+        self.ensure_tool_available("proxmox.vm.status")?;
+        let start = Instant::now();
+        let result = proxmox::vm_status(
+            self.manager.clone(),
+            args.host,
+            args.node,
+            args.vmid,
+            args.vm_type,
+            self.audit.clone(),
+        )
+        .await
+        .map_err(|error| error.to_string());
+        self.record_tool_call("proxmox.vm.status", start, result.is_err());
+        result
+    }
+
+    #[tool(
+        name = "proxmox.vm.start",
+        description = "Start a Proxmox VM or LXC container",
+        annotations(destructive_hint = false, idempotent_hint = true)
+    )]
+    async fn proxmox_vm_start(
+        &self,
+        Parameters(args): Parameters<ProxmoxVmStartArgs>,
+    ) -> Result<String, String> {
+        self.ensure_tool_available("proxmox.vm.start")?;
+        let start = Instant::now();
+        let result = proxmox::vm_start(
+            self.manager.clone(),
+            args.host,
+            args.node,
+            args.vmid,
+            args.vm_type,
+            args.dry_run,
+            self.audit.clone(),
+        )
+        .await
+        .map_err(|error| error.to_string());
+        self.record_tool_call("proxmox.vm.start", start, result.is_err());
+        result
+    }
+
+    #[tool(
+        name = "proxmox.vm.stop",
+        description = "Stop (graceful shutdown) a Proxmox VM or LXC container. When confirmation is configured, this is a TWO-STEP operation: (1) Call this tool and get a confirmation token. (2) Call confirm_operation to execute.",
+        annotations(destructive_hint = true)
+    )]
+    async fn proxmox_vm_stop(
+        &self,
+        Parameters(args): Parameters<ProxmoxVmStopArgs>,
+    ) -> Result<String, String> {
+        self.ensure_tool_available("proxmox.vm.stop")?;
+        let start = Instant::now();
+        let result = proxmox::vm_stop(
+            self.manager.clone(),
+            self.confirmation.clone(),
+            args.host,
+            args.node,
+            args.vmid,
+            args.vm_type,
+            args.dry_run,
+            self.audit.clone(),
+        )
+        .await
+        .map_err(|error| error.to_string());
+        self.record_tool_call("proxmox.vm.stop", start, result.is_err());
+        result
+    }
+
+    #[tool(
+        name = "proxmox.vm.create",
+        description = "Create a new Proxmox VM or LXC container. Use dry_run=true to preview. This is a TWO-STEP operation when confirmation is configured.",
+        annotations(destructive_hint = true)
+    )]
+    async fn proxmox_vm_create(
+        &self,
+        Parameters(args): Parameters<ProxmoxVmCreateArgs>,
+    ) -> Result<String, String> {
+        self.ensure_tool_available("proxmox.vm.create")?;
+        let start = Instant::now();
+        let result = proxmox::vm_create(
+            self.manager.clone(),
+            self.confirmation.clone(),
+            args.host,
+            args.node,
+            args.vmid,
+            args.vm_type,
+            args.name,
+            args.cores,
+            args.memory,
+            args.ostype,
+            args.iso,
+            args.storage,
+            args.disk_size,
+            args.net,
+            args.dry_run,
+            self.audit.clone(),
+        )
+        .await
+        .map_err(|error| error.to_string());
+        self.record_tool_call("proxmox.vm.create", start, result.is_err());
+        result
+    }
+
+    #[tool(
+        name = "proxmox.vm.clone",
+        description = "Clone an existing Proxmox VM from a template or existing VM. Supports full and linked clones.",
+        annotations(destructive_hint = false)
+    )]
+    async fn proxmox_vm_clone(
+        &self,
+        Parameters(args): Parameters<ProxmoxVmCloneArgs>,
+    ) -> Result<String, String> {
+        self.ensure_tool_available("proxmox.vm.clone")?;
+        let start = Instant::now();
+        let result = proxmox::vm_clone(
+            self.manager.clone(),
+            args.host,
+            args.node,
+            args.vmid,
+            args.newid,
+            args.name,
+            args.full,
+            args.target_storage,
+            args.dry_run,
+            self.audit.clone(),
+        )
+        .await
+        .map_err(|error| error.to_string());
+        self.record_tool_call("proxmox.vm.clone", start, result.is_err());
+        result
+    }
+
+    #[tool(
+        name = "proxmox.vm.delete",
+        description = "PERMANENTLY delete a Proxmox VM or LXC container. Use dry_run=true first. This is a TWO-STEP operation: (1) Returns a confirmation token. (2) Call confirm_operation to execute.",
+        annotations(destructive_hint = true)
+    )]
+    async fn proxmox_vm_delete(
+        &self,
+        Parameters(args): Parameters<ProxmoxVmDeleteArgs>,
+    ) -> Result<String, String> {
+        self.ensure_tool_available("proxmox.vm.delete")?;
+        let start = Instant::now();
+        let result = proxmox::vm_delete(
+            self.manager.clone(),
+            self.confirmation.clone(),
+            args.host,
+            args.node,
+            args.vmid,
+            args.vm_type,
+            args.purge,
+            args.dry_run,
+            self.audit.clone(),
+        )
+        .await
+        .map_err(|error| error.to_string());
+        self.record_tool_call("proxmox.vm.delete", start, result.is_err());
+        result
+    }
+
+    #[tool(
+        name = "proxmox.vm.snapshot.list",
+        description = "List snapshots for a Proxmox VM or LXC container",
+        annotations(read_only_hint = true, idempotent_hint = true)
+    )]
+    async fn proxmox_snapshot_list(
+        &self,
+        Parameters(args): Parameters<ProxmoxSnapshotListArgs>,
+    ) -> Result<String, String> {
+        self.ensure_tool_available("proxmox.vm.snapshot.list")?;
+        let start = Instant::now();
+        let result = proxmox::snapshot_list(
+            self.manager.clone(),
+            args.host,
+            args.node,
+            args.vmid,
+            args.vm_type,
+            self.audit.clone(),
+        )
+        .await
+        .map_err(|error| error.to_string());
+        self.record_tool_call("proxmox.vm.snapshot.list", start, result.is_err());
+        result
+    }
+
+    #[tool(
+        name = "proxmox.vm.snapshot.create",
+        description = "Create a snapshot of a Proxmox VM or LXC container",
+        annotations(destructive_hint = false)
+    )]
+    async fn proxmox_snapshot_create(
+        &self,
+        Parameters(args): Parameters<ProxmoxSnapshotCreateArgs>,
+    ) -> Result<String, String> {
+        self.ensure_tool_available("proxmox.vm.snapshot.create")?;
+        let start = Instant::now();
+        let result = proxmox::snapshot_create(
+            self.manager.clone(),
+            args.host,
+            args.node,
+            args.vmid,
+            args.vm_type,
+            args.snapname,
+            args.description,
+            args.vmstate,
+            args.dry_run,
+            self.audit.clone(),
+        )
+        .await
+        .map_err(|error| error.to_string());
+        self.record_tool_call("proxmox.vm.snapshot.create", start, result.is_err());
+        result
+    }
+
+    #[tool(
+        name = "proxmox.vm.snapshot.rollback",
+        description = "Rollback a Proxmox VM or LXC container to a previous snapshot. WARNING: Current state will be lost. This is a TWO-STEP operation when confirmation is configured.",
+        annotations(destructive_hint = true)
+    )]
+    async fn proxmox_snapshot_rollback(
+        &self,
+        Parameters(args): Parameters<ProxmoxSnapshotRollbackArgs>,
+    ) -> Result<String, String> {
+        self.ensure_tool_available("proxmox.vm.snapshot.rollback")?;
+        let start = Instant::now();
+        let result = proxmox::snapshot_rollback(
+            self.manager.clone(),
+            self.confirmation.clone(),
+            args.host,
+            args.node,
+            args.vmid,
+            args.vm_type,
+            args.snapname,
+            args.dry_run,
+            self.audit.clone(),
+        )
+        .await
+        .map_err(|error| error.to_string());
+        self.record_tool_call("proxmox.vm.snapshot.rollback", start, result.is_err());
+        result
+    }
+
+    #[tool(
+        name = "proxmox.storage.list",
+        description = "List Proxmox storage pools with usage information (type, capacity, content types)",
+        annotations(read_only_hint = true, idempotent_hint = true)
+    )]
+    async fn proxmox_storage_list(
+        &self,
+        Parameters(args): Parameters<ProxmoxStorageListArgs>,
+    ) -> Result<String, String> {
+        self.ensure_tool_available("proxmox.storage.list")?;
+        let start = Instant::now();
+        let result = proxmox::storage_list(
+            self.manager.clone(),
+            args.host,
+            args.node,
+            self.audit.clone(),
+        )
+        .await
+        .map_err(|error| error.to_string());
+        self.record_tool_call("proxmox.storage.list", start, result.is_err());
+        result
+    }
+
+    #[tool(
+        name = "proxmox.network.list",
+        description = "List Proxmox network interfaces (bridges, VLANs, bonds, physical NICs)",
+        annotations(read_only_hint = true, idempotent_hint = true)
+    )]
+    async fn proxmox_network_list(
+        &self,
+        Parameters(args): Parameters<ProxmoxNetworkListArgs>,
+    ) -> Result<String, String> {
+        self.ensure_tool_available("proxmox.network.list")?;
+        let start = Instant::now();
+        let result = proxmox::network_list(
+            self.manager.clone(),
+            args.host,
+            args.node,
+            self.audit.clone(),
+        )
+        .await
+        .map_err(|error| error.to_string());
+        self.record_tool_call("proxmox.network.list", start, result.is_err());
+        result
+    }
+
+    #[tool(
         name = "ssh.exec",
         description = "Execute a command on a remote host via SSH",
         annotations(destructive_hint = true, open_world_hint = true)
@@ -876,6 +1447,109 @@ impl HomelabMcpServer {
                     self.manager.clone(),
                     params.host.unwrap_or_else(|| "local".to_string()),
                     params.all.unwrap_or(false),
+                    self.audit.clone(),
+                )
+                .await
+                .map_err(|error| error.to_string())
+            }
+            "proxmox.vm.stop" => {
+                let params: ProxmoxVmStopArgs = serde_json::from_str(&original_params_json)
+                    .map_err(|error| error.to_string())?;
+                self.audit
+                    .log(
+                        "proxmox.vm.stop",
+                        params.host.as_deref().unwrap_or("default"),
+                        "confirmed_exec",
+                        Some(&params.vmid.to_string()),
+                    )
+                    .await
+                    .ok();
+                proxmox::vm_stop_confirmed(
+                    self.manager.clone(),
+                    params.host.unwrap_or_else(|| "default".to_string()),
+                    params.node,
+                    params.vmid,
+                    params.vm_type,
+                    self.audit.clone(),
+                )
+                .await
+                .map_err(|error| error.to_string())
+            }
+            "proxmox.vm.create" => {
+                let params: ProxmoxVmCreateArgs = serde_json::from_str(&original_params_json)
+                    .map_err(|error| error.to_string())?;
+                self.audit
+                    .log(
+                        "proxmox.vm.create",
+                        params.host.as_deref().unwrap_or("default"),
+                        "confirmed_exec",
+                        params.name.as_deref(),
+                    )
+                    .await
+                    .ok();
+                proxmox::vm_create_confirmed(
+                    self.manager.clone(),
+                    params.host.unwrap_or_else(|| "default".to_string()),
+                    params.node,
+                    params.vmid,
+                    params.vm_type.unwrap_or_else(|| "qemu".to_string()),
+                    params.name,
+                    params.cores,
+                    params.memory,
+                    params.ostype,
+                    params.iso,
+                    params.storage,
+                    params.disk_size,
+                    params.net,
+                    self.audit.clone(),
+                )
+                .await
+                .map_err(|error| error.to_string())
+            }
+            "proxmox.vm.delete" => {
+                let params: ProxmoxVmDeleteArgs = serde_json::from_str(&original_params_json)
+                    .map_err(|error| error.to_string())?;
+                self.audit
+                    .log(
+                        "proxmox.vm.delete",
+                        params.host.as_deref().unwrap_or("default"),
+                        "confirmed_exec",
+                        Some(&params.vmid.to_string()),
+                    )
+                    .await
+                    .ok();
+                proxmox::vm_delete_confirmed(
+                    self.manager.clone(),
+                    params.host.unwrap_or_else(|| "default".to_string()),
+                    params.node,
+                    params.vmid,
+                    params.vm_type.unwrap_or_else(|| "qemu".to_string()),
+                    params.purge,
+                    self.audit.clone(),
+                )
+                .await
+                .map_err(|error| error.to_string())
+            }
+            "proxmox.vm.snapshot.rollback" => {
+                let params: ProxmoxSnapshotRollbackArgs =
+                    serde_json::from_str(&original_params_json)
+                        .map_err(|error| error.to_string())?;
+                self.audit
+                    .log(
+                        "proxmox.vm.snapshot.rollback",
+                        params.host.as_deref().unwrap_or("default"),
+                        "confirmed_exec",
+                        Some(&params.snapname),
+                    )
+                    .await
+                    .ok();
+                proxmox::snapshot_rollback_confirmed(
+                    self.manager.clone(),
+                    params.host.unwrap_or_else(|| "default".to_string()),
+                    params.node,
+                    params.vmid,
+                    params.vm_type.unwrap_or_else(|| "qemu".to_string()),
+                    params.snapname,
                     self.audit.clone(),
                 )
                 .await

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -256,8 +256,10 @@ struct ProxmoxVmCreateArgs {
     pub cores: Option<u64>,
     /// Memory in MB
     pub memory: Option<u64>,
-    /// OS type for QEMU (e.g. "l26" for Linux) or template path for LXC
-    pub ostype: Option<String>,
+    /// QEMU OS type identifier (e.g. "l26" for Linux)
+    pub os_type: Option<String>,
+    /// LXC template path (e.g. "local:vztmpl/ubuntu-24.04-standard_24.04-1_amd64.tar.zst")
+    pub template: Option<String>,
     /// ISO image for QEMU (e.g. "local:iso/ubuntu-22.04.iso")
     pub iso: Option<String>,
     /// Storage pool for disk (e.g. "local-lvm")
@@ -978,7 +980,7 @@ impl HomelabMcpServer {
 
     #[tool(
         name = "proxmox.vm.stop",
-        description = "Stop (graceful shutdown) a Proxmox VM or LXC container. When confirmation is configured, this is a TWO-STEP operation: (1) Call this tool and get a confirmation token. (2) Call confirm_operation to execute.",
+        description = "Force-stop a Proxmox VM or LXC container immediately. When confirmation is configured, this is a TWO-STEP operation: (1) Call this tool and get a confirmation token. (2) Call confirm_operation with that token and tool_name=\"proxmox.vm.stop\" to execute.",
         annotations(destructive_hint = true)
     )]
     async fn proxmox_vm_stop(
@@ -1005,7 +1007,7 @@ impl HomelabMcpServer {
 
     #[tool(
         name = "proxmox.vm.create",
-        description = "Create a new Proxmox VM or LXC container. Use dry_run=true to preview. This is a TWO-STEP operation when confirmation is configured.",
+        description = "Create a new Proxmox VM or LXC container. Use dry_run=true to preview. When confirmation is configured, this is a TWO-STEP operation: (1) Call this tool and get a confirmation token. (2) Call confirm_operation with that token and tool_name=\"proxmox.vm.create\" to execute.",
         annotations(destructive_hint = true)
     )]
     async fn proxmox_vm_create(
@@ -1024,7 +1026,8 @@ impl HomelabMcpServer {
             args.name,
             args.cores,
             args.memory,
-            args.ostype,
+            args.os_type,
+            args.template,
             args.iso,
             args.storage,
             args.disk_size,
@@ -1069,7 +1072,7 @@ impl HomelabMcpServer {
 
     #[tool(
         name = "proxmox.vm.delete",
-        description = "PERMANENTLY delete a Proxmox VM or LXC container. Use dry_run=true first. This is a TWO-STEP operation: (1) Returns a confirmation token. (2) Call confirm_operation to execute.",
+        description = "PERMANENTLY delete a Proxmox VM or LXC container. Use dry_run=true first. This is a TWO-STEP operation: (1) Returns a confirmation token. (2) Call confirm_operation with that token and tool_name=\"proxmox.vm.delete\" to execute.",
         annotations(destructive_hint = true)
     )]
     async fn proxmox_vm_delete(
@@ -1151,7 +1154,7 @@ impl HomelabMcpServer {
 
     #[tool(
         name = "proxmox.vm.snapshot.rollback",
-        description = "Rollback a Proxmox VM or LXC container to a previous snapshot. WARNING: Current state will be lost. This is a TWO-STEP operation when confirmation is configured.",
+        description = "Rollback a Proxmox VM or LXC container to a previous snapshot. WARNING: Current state will be lost. When confirmation is configured, this is a TWO-STEP operation: (1) Call this tool and get a confirmation token. (2) Call confirm_operation with that token and tool_name=\"proxmox.vm.snapshot.rollback\" to execute.",
         annotations(destructive_hint = true)
     )]
     async fn proxmox_snapshot_rollback(
@@ -1504,7 +1507,8 @@ impl HomelabMcpServer {
                     params.name,
                     params.cores,
                     params.memory,
-                    params.ostype,
+                    params.os_type,
+                    params.template,
                     params.iso,
                     params.storage,
                     params.disk_size,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -32,6 +32,9 @@ pub struct Metrics {
     /// SSH connection health (labels: host; 1=connected, 0=disconnected)
     pub ssh_health: IntGaugeVec,
 
+    /// Proxmox connection health (labels: host; 1=connected, 0=disconnected)
+    pub proxmox_health: IntGaugeVec,
+
     /// Confirmation tokens issued
     pub confirmation_tokens_issued: IntCounterVec,
 
@@ -99,6 +102,15 @@ impl Metrics {
         )
         .expect("ssh_health metric");
 
+        let proxmox_health = IntGaugeVec::new(
+            Opts::new(
+                "proxmox_connection_healthy",
+                "Proxmox VE connection health (1=up, 0=down)",
+            ),
+            &["host"],
+        )
+        .expect("proxmox_health metric");
+
         let confirmation_tokens_issued = IntCounterVec::new(
             Opts::new(
                 "confirmation_tokens_issued_total",
@@ -126,6 +138,7 @@ impl Metrics {
             Box::new(ssh_pool_total.clone()),
             Box::new(docker_health.clone()),
             Box::new(ssh_health.clone()),
+            Box::new(proxmox_health.clone()),
             Box::new(confirmation_tokens_issued.clone()),
             Box::new(confirmation_tokens_resolved.clone()),
         ] {
@@ -141,6 +154,7 @@ impl Metrics {
             ssh_pool_total,
             docker_health,
             ssh_health,
+            proxmox_health,
             confirmation_tokens_issued,
             confirmation_tokens_resolved,
         }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2,6 +2,8 @@
 pub mod docker;
 /// Docker image tools
 pub mod docker_image;
+/// Proxmox VE tools
+pub mod proxmox;
 /// SSH tools
 pub mod ssh;
 /// Audit verification tool

--- a/src/tools/proxmox.rs
+++ b/src/tools/proxmox.rs
@@ -1,6 +1,8 @@
 use anyhow::{Result, anyhow};
 use serde_json::Value;
 use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
 
 use crate::audit::AuditLogger;
 use crate::confirmation::ConfirmationManager;
@@ -9,6 +11,12 @@ use crate::tools::{truncate_output, wrap_output_envelope};
 
 const OUTPUT_MAX_CHARS: usize = 10_000;
 const DEFAULT_TASK_WAIT_TIMEOUT_SECS: u64 = 600;
+
+#[derive(Clone, Copy)]
+struct AutoVmidRetryPolicy {
+    attempts: usize,
+    backoff_ms: u64,
+}
 
 pub async fn node_list(
     manager: Arc<ConnectionManager>,
@@ -506,7 +514,7 @@ pub async fn vm_stop(
 
     if dry_run.unwrap_or(false) {
         let output = format!(
-            "DRY RUN: Would stop {} {} on Proxmox host '{}'.",
+            "DRY RUN: Would force-stop {} {} on Proxmox host '{}'.",
             vm_type, vmid, host
         );
         audit
@@ -529,7 +537,7 @@ pub async fn vm_stop(
             "proxmox.vm.stop",
             None,
             &format!(
-                "About to STOP {} {} on Proxmox host '{}'. The VM/CT will be shut down.",
+                "About to FORCE-STOP {} {} on Proxmox host '{}'. The VM/CT will be stopped immediately.",
                 vm_type, vmid, host
             ),
             &params_json,
@@ -563,7 +571,7 @@ pub async fn vm_stop_confirmed(
         let client = manager.get_proxmox(&host)?;
         let node_name = client.resolve_node(node.as_deref()).await?;
         let vm_type = resolved_vm_type(vm_type.as_deref())?;
-        let path = format!("/nodes/{}/{}/{}/status/shutdown", node_name, vm_type, vmid);
+        let path = format!("/nodes/{}/{}/{}/status/stop", node_name, vm_type, vmid);
         let response = client.post(&path, &[]).await?;
 
         if let Some(upid) = response.as_str() {
@@ -571,12 +579,12 @@ pub async fn vm_stop_confirmed(
                 .wait_for_task(&node_name, upid, task_wait_timeout_secs(&manager, &host))
                 .await?;
             Ok(format!(
-                "Stopped {} {} on node '{}'. {}",
+                "Force-stopped {} {} on node '{}'. {}",
                 vm_type, vmid, node_name, result
             ))
         } else {
             Ok(format!(
-                "Stop requested for {} {} on node '{}'.",
+                "Force-stop requested for {} {} on node '{}'.",
                 vm_type, vmid, node_name
             ))
         }
@@ -612,7 +620,8 @@ pub async fn vm_create(
     name: Option<String>,
     cores: Option<u64>,
     memory: Option<u64>,
-    ostype: Option<String>,
+    os_type: Option<String>,
+    template: Option<String>,
     iso: Option<String>,
     storage: Option<String>,
     disk_size: Option<String>,
@@ -624,6 +633,7 @@ pub async fn vm_create(
     let vm_type = vm_type.unwrap_or_else(|| "qemu".to_string());
 
     ensure_vm_type(&vm_type)?;
+    validate_vm_create_platform_inputs(&vm_type, os_type.as_deref(), template.as_deref())?;
 
     let mut param_lines = vec![format!("Type: {}", vm_type)];
     if let Some(vmid) = vmid {
@@ -638,8 +648,12 @@ pub async fn vm_create(
     if let Some(memory) = memory {
         param_lines.push(format!("Memory: {} MB", memory));
     }
-    if let Some(ostype) = &ostype {
-        param_lines.push(format!("OS Type: {}", ostype));
+    if vm_type == "qemu" {
+        if let Some(os_type) = &os_type {
+            param_lines.push(format!("OS Type: {}", os_type));
+        }
+    } else if let Some(template) = &template {
+        param_lines.push(format!("Template: {}", template));
     }
     if let Some(iso) = &iso {
         param_lines.push(format!("ISO: {}", iso));
@@ -676,7 +690,8 @@ pub async fn vm_create(
         "name": name.clone(),
         "cores": cores,
         "memory": memory,
-        "ostype": ostype.clone(),
+        "os_type": os_type.clone(),
+        "template": template.clone(),
         "iso": iso.clone(),
         "storage": storage.clone(),
         "disk_size": disk_size.clone(),
@@ -711,8 +726,8 @@ pub async fn vm_create(
     }
 
     vm_create_confirmed(
-        manager, host, node, vmid, vm_type, name, cores, memory, ostype, iso, storage, disk_size,
-        net, audit,
+        manager, host, node, vmid, vm_type, name, cores, memory, os_type, template, iso, storage,
+        disk_size, net, audit,
     )
     .await
 }
@@ -727,7 +742,8 @@ pub async fn vm_create_confirmed(
     name: Option<String>,
     cores: Option<u64>,
     memory: Option<u64>,
-    ostype: Option<String>,
+    os_type: Option<String>,
+    template: Option<String>,
     iso: Option<String>,
     storage: Option<String>,
     disk_size: Option<String>,
@@ -738,70 +754,101 @@ pub async fn vm_create_confirmed(
         let client = manager.get_proxmox(&host)?;
         let node_name = client.resolve_node(node.as_deref()).await?;
         let vm_type = resolved_vm_type(Some(&vm_type))?;
-        let vmid = match vmid {
+        validate_vm_create_platform_inputs(vm_type, os_type.as_deref(), template.as_deref())?;
+        let retry_policy = auto_vmid_retry_policy(&manager, &host);
+        let auto_vmid = vmid.is_none();
+        let mut vmid = match vmid {
             Some(vmid) => vmid,
             None => next_vmid(&client).await?,
         };
-
-        let mut params: Vec<(&str, String)> = vec![("vmid", vmid.to_string())];
-
-        if let Some(name) = &name {
-            params.push(("name", name.clone()));
-        }
-        if let Some(cores) = cores {
-            params.push(("cores", cores.to_string()));
-        }
-        if let Some(memory) = memory {
-            params.push(("memory", memory.to_string()));
-        }
-
-        if vm_type == "qemu" {
-            if let Some(ostype) = &ostype {
-                params.push(("ostype", ostype.clone()));
-            }
-            if let Some(iso) = &iso {
-                params.push(("ide2", format!("{},media=cdrom", iso)));
-            }
-            if let Some(storage) = &storage {
-                let size = disk_size.as_deref().unwrap_or("32G");
-                params.push(("scsi0", format!("{}:{}", storage, size)));
-            }
-            if let Some(net) = &net {
-                params.push(("net0", net.clone()));
-            }
-        } else {
-            if let Some(ostype) = &ostype {
-                params.push(("ostemplate", ostype.clone()));
-            }
-            if let Some(storage) = &storage {
-                let size = disk_size.as_deref().unwrap_or("8");
-                params.push(("rootfs", format!("{}:{}", storage, size)));
-            }
-            if let Some(net) = &net {
-                params.push(("net0", net.clone()));
-            }
-        }
-
-        let param_refs: Vec<(&str, &str)> = params
-            .iter()
-            .map(|(key, value)| (*key, value.as_str()))
-            .collect();
         let path = format!("/nodes/{}/{}", node_name, vm_type);
-        let response = client.post(&path, &param_refs).await?;
+        let mut conflict_retries = 0usize;
 
-        if let Some(upid) = response.as_str() {
-            let result = client
-                .wait_for_task(&node_name, upid, task_wait_timeout_secs(&manager, &host))
-                .await?;
-            Ok(format!(
-                "Created {} {} on node '{}'. {}",
-                vm_type, vmid, node_name, result
-            ))
-        } else {
-            Ok(format!(
-                "Created {} {} on node '{}'.",
-                vm_type, vmid, node_name
-            ))
+        loop {
+            let mut params: Vec<(&str, String)> = vec![("vmid", vmid.to_string())];
+
+            if let Some(name) = &name {
+                params.push(("name", name.clone()));
+            }
+            if let Some(cores) = cores {
+                params.push(("cores", cores.to_string()));
+            }
+            if let Some(memory) = memory {
+                params.push(("memory", memory.to_string()));
+            }
+
+            if vm_type == "qemu" {
+                if let Some(os_type) = &os_type {
+                    params.push(("ostype", os_type.clone()));
+                }
+                if let Some(iso) = &iso {
+                    params.push(("ide2", format!("{},media=cdrom", iso)));
+                }
+                if let Some(storage) = &storage {
+                    let size = disk_size.as_deref().unwrap_or("32G");
+                    params.push(("scsi0", format!("{}:{}", storage, size)));
+                }
+                if let Some(net) = &net {
+                    params.push(("net0", net.clone()));
+                }
+            } else {
+                if let Some(template) = &template {
+                    params.push(("ostemplate", template.clone()));
+                }
+                if let Some(storage) = &storage {
+                    let size = disk_size.as_deref().unwrap_or("8");
+                    params.push(("rootfs", format!("{}:{}", storage, size)));
+                }
+                if let Some(net) = &net {
+                    params.push(("net0", net.clone()));
+                }
+            }
+
+            let param_refs: Vec<(&str, &str)> = params
+                .iter()
+                .map(|(key, value)| (*key, value.as_str()))
+                .collect();
+
+            match client.post(&path, &param_refs).await {
+                Ok(response) => {
+                    break if let Some(upid) = response.as_str() {
+                        let result = client
+                            .wait_for_task(
+                                &node_name,
+                                upid,
+                                task_wait_timeout_secs(&manager, &host),
+                            )
+                            .await?;
+                        Ok(format!(
+                            "Created {} {} on node '{}'. {}",
+                            vm_type, vmid, node_name, result
+                        ))
+                    } else {
+                        Ok(format!(
+                            "Created {} {} on node '{}'.",
+                            vm_type, vmid, node_name
+                        ))
+                    };
+                }
+                Err(error)
+                    if auto_vmid
+                        && is_duplicate_vmid_conflict(&error, vmid)
+                        && conflict_retries < retry_policy.attempts =>
+                {
+                    conflict_retries += 1;
+                    sleep(Duration::from_millis(retry_policy.backoff_ms)).await;
+                    vmid = next_vmid(&client).await?;
+                }
+                Err(error) if auto_vmid && is_duplicate_vmid_conflict(&error, vmid) => {
+                    break Err(exhausted_auto_vmid_error(
+                        "proxmox.vm.create",
+                        "vmid",
+                        retry_policy,
+                        error,
+                    ));
+                }
+                Err(error) => break Err(error),
+            }
         }
     }
     .await;
@@ -870,48 +917,78 @@ pub async fn vm_clone(
     let result: Result<String> = async {
         let client = manager.get_proxmox(&host)?;
         let node_name = client.resolve_node(node.as_deref()).await?;
-        let newid = match newid {
+        let retry_policy = auto_vmid_retry_policy(&manager, &host);
+        let auto_newid = newid.is_none();
+        let mut newid = match newid {
             Some(newid) => newid,
             None => next_vmid(&client).await?,
         };
-
-        let mut params: Vec<(&str, String)> = vec![("newid", newid.to_string())];
-        if let Some(name) = &name {
-            params.push(("name", name.clone()));
-        }
-        if let Some(full) = full {
-            params.push(("full", bool_to_proxmox(full).to_string()));
-        }
-        if let Some(target_storage) = &target_storage {
-            params.push(("storage", target_storage.clone()));
-        }
-
-        let param_refs: Vec<(&str, &str)> = params
-            .iter()
-            .map(|(key, value)| (*key, value.as_str()))
-            .collect();
         let path = format!("/nodes/{}/qemu/{}/clone", node_name, vmid);
-        let response = client.post(&path, &param_refs).await?;
+        let mut conflict_retries = 0usize;
 
-        if let Some(upid) = response.as_str() {
-            let result = client
-                .wait_for_task(&node_name, upid, task_wait_timeout_secs(&manager, &host))
-                .await?;
-            Ok(format!(
-                "Cloned VM {} to {} on node '{}'. {}\n{}",
-                vmid,
-                newid,
-                node_name,
-                result,
-                name.as_ref()
-                    .map(|name| format!("Name: {}", name))
-                    .unwrap_or_default(),
-            ))
-        } else {
-            Ok(format!(
-                "Clone requested for VM {} to {} on node '{}'.",
-                vmid, newid, node_name
-            ))
+        loop {
+            let mut params: Vec<(&str, String)> = vec![("newid", newid.to_string())];
+            if let Some(name) = &name {
+                params.push(("name", name.clone()));
+            }
+            if let Some(full) = full {
+                params.push(("full", bool_to_proxmox(full).to_string()));
+            }
+            if let Some(target_storage) = &target_storage {
+                params.push(("storage", target_storage.clone()));
+            }
+
+            let param_refs: Vec<(&str, &str)> = params
+                .iter()
+                .map(|(key, value)| (*key, value.as_str()))
+                .collect();
+
+            match client.post(&path, &param_refs).await {
+                Ok(response) => {
+                    break if let Some(upid) = response.as_str() {
+                        let result = client
+                            .wait_for_task(
+                                &node_name,
+                                upid,
+                                task_wait_timeout_secs(&manager, &host),
+                            )
+                            .await?;
+                        Ok(format!(
+                            "Cloned VM {} to {} on node '{}'. {}\n{}",
+                            vmid,
+                            newid,
+                            node_name,
+                            result,
+                            name.as_ref()
+                                .map(|name| format!("Name: {}", name))
+                                .unwrap_or_default(),
+                        ))
+                    } else {
+                        Ok(format!(
+                            "Clone requested for VM {} to {} on node '{}'.",
+                            vmid, newid, node_name
+                        ))
+                    };
+                }
+                Err(error)
+                    if auto_newid
+                        && is_duplicate_vmid_conflict(&error, newid)
+                        && conflict_retries < retry_policy.attempts =>
+                {
+                    conflict_retries += 1;
+                    sleep(Duration::from_millis(retry_policy.backoff_ms)).await;
+                    newid = next_vmid(&client).await?;
+                }
+                Err(error) if auto_newid && is_duplicate_vmid_conflict(&error, newid) => {
+                    break Err(exhausted_auto_vmid_error(
+                        "proxmox.vm.clone",
+                        "newid",
+                        retry_policy,
+                        error,
+                    ));
+                }
+                Err(error) => break Err(error),
+            }
         }
     }
     .await;
@@ -1604,6 +1681,22 @@ fn task_wait_timeout_secs(manager: &ConnectionManager, host: &str) -> u64 {
         .unwrap_or(DEFAULT_TASK_WAIT_TIMEOUT_SECS)
 }
 
+fn auto_vmid_retry_policy(manager: &ConnectionManager, host: &str) -> AutoVmidRetryPolicy {
+    manager
+        .config()
+        .proxmox
+        .hosts
+        .get(host)
+        .map(|host| AutoVmidRetryPolicy {
+            attempts: host.next_vmid_retry_attempts,
+            backoff_ms: host.next_vmid_retry_backoff_ms,
+        })
+        .unwrap_or(AutoVmidRetryPolicy {
+            attempts: 3,
+            backoff_ms: 250,
+        })
+}
+
 fn ensure_vm_type(vm_type: &str) -> Result<()> {
     match vm_type {
         "qemu" | "lxc" => Ok(()),
@@ -1617,12 +1710,56 @@ fn resolved_vm_type(vm_type: Option<&str>) -> Result<&str> {
     Ok(vm_type)
 }
 
+fn validate_vm_create_platform_inputs(
+    vm_type: &str,
+    os_type: Option<&str>,
+    template: Option<&str>,
+) -> Result<()> {
+    match vm_type {
+        "qemu" if template.is_some() => {
+            Err(anyhow!("template is only valid when vm_type is 'lxc'"))
+        }
+        "lxc" if os_type.is_some() => Err(anyhow!("os_type is only valid when vm_type is 'qemu'")),
+        _ => Ok(()),
+    }
+}
+
 async fn next_vmid(client: &ProxmoxClient) -> Result<u64> {
     let next = client.get("/cluster/nextid").await?;
     next.as_str()
         .and_then(|value| value.parse::<u64>().ok())
         .or_else(|| next.as_u64())
         .ok_or_else(|| anyhow!("Failed to get next available VMID"))
+}
+
+fn is_duplicate_vmid_conflict(error: &anyhow::Error, vmid: u64) -> bool {
+    let message = error.to_string().to_ascii_lowercase();
+    let vmid_text = vmid.to_string();
+    let mentions_conflict = message.contains("already exists")
+        || message.contains("already used")
+        || message.contains("already in use")
+        || message.contains("duplicate");
+    let mentions_vmid = message.contains(&format!("vm {}", vmid))
+        || message.contains(&format!("ct {}", vmid))
+        || (message.contains("vmid") && message.contains(&vmid_text));
+
+    mentions_conflict && mentions_vmid
+}
+
+fn exhausted_auto_vmid_error(
+    tool_name: &str,
+    field_name: &str,
+    retry_policy: AutoVmidRetryPolicy,
+    last_error: anyhow::Error,
+) -> anyhow::Error {
+    anyhow!(
+        "{} failed after {} auto-VMID conflict retries ({}ms backoff). Pass an explicit {} or increase next_vmid_retry_attempts/next_vmid_retry_backoff_ms. Last error: {}",
+        tool_name,
+        retry_policy.attempts,
+        retry_policy.backoff_ms,
+        field_name,
+        last_error,
+    )
 }
 
 fn bool_to_proxmox(value: bool) -> &'static str {
@@ -1691,5 +1828,88 @@ fn format_bytes(bytes: u64) -> String {
         format!("{:.1} KB", bytes as f64 / KB as f64)
     } else {
         format!("{} B", bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AutoVmidRetryPolicy, exhausted_auto_vmid_error, is_duplicate_vmid_conflict,
+        validate_vm_create_platform_inputs,
+    };
+
+    #[test]
+    fn qemu_accepts_os_type_without_template() {
+        assert!(validate_vm_create_platform_inputs("qemu", Some("l26"), None).is_ok());
+    }
+
+    #[test]
+    fn lxc_accepts_template_without_os_type() {
+        assert!(
+            validate_vm_create_platform_inputs(
+                "lxc",
+                None,
+                Some("local:vztmpl/ubuntu-24.04-standard_24.04-1_amd64.tar.zst")
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn qemu_rejects_lxc_template_field() {
+        let error =
+            validate_vm_create_platform_inputs("qemu", Some("l26"), Some("template")).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("template is only valid when vm_type is 'lxc'")
+        );
+    }
+
+    #[test]
+    fn lxc_rejects_qemu_os_type_field() {
+        let error =
+            validate_vm_create_platform_inputs("lxc", Some("l26"), Some("template")).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("os_type is only valid when vm_type is 'qemu'")
+        );
+    }
+
+    #[test]
+    fn detects_duplicate_vmid_conflict_error() {
+        let error = anyhow::anyhow!(
+            "Proxmox API error (HTTP 500): {{\"errors\":{{\"vmid\":\"VM 123 already exists\"}}}}"
+        );
+
+        assert!(is_duplicate_vmid_conflict(&error, 123));
+    }
+
+    #[test]
+    fn ignores_non_vmid_conflict_error() {
+        let error = anyhow::anyhow!(
+            "Proxmox API error (HTTP 500): {{\"errors\":{{\"name\":\"guest name already exists\"}}}}"
+        );
+
+        assert!(!is_duplicate_vmid_conflict(&error, 123));
+    }
+
+    #[test]
+    fn exhausted_auto_vmid_error_mentions_config_and_field() {
+        let error = exhausted_auto_vmid_error(
+            "proxmox.vm.create",
+            "vmid",
+            AutoVmidRetryPolicy {
+                attempts: 3,
+                backoff_ms: 250,
+            },
+            anyhow::anyhow!("VM 123 already exists"),
+        );
+
+        let message = error.to_string();
+        assert!(message.contains("proxmox.vm.create failed after 3 auto-VMID conflict retries"));
+        assert!(message.contains("Pass an explicit vmid"));
+        assert!(message.contains("next_vmid_retry_attempts/next_vmid_retry_backoff_ms"));
     }
 }

--- a/src/tools/proxmox.rs
+++ b/src/tools/proxmox.rs
@@ -8,14 +8,14 @@ use crate::connection::{ConnectionManager, ProxmoxClient};
 use crate::tools::{truncate_output, wrap_output_envelope};
 
 const OUTPUT_MAX_CHARS: usize = 10_000;
-const TASK_WAIT_TIMEOUT_SECS: u64 = 120;
+const DEFAULT_TASK_WAIT_TIMEOUT_SECS: u64 = 600;
 
 pub async fn node_list(
     manager: Arc<ConnectionManager>,
     host: Option<String>,
     audit: Arc<AuditLogger>,
 ) -> Result<String> {
-    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let host = host.map_or_else(|| default_proxmox_host(&manager), Ok)?;
     let result: Result<String> = async {
         let client = manager.get_proxmox(&host)?;
         let nodes = client.get("/nodes").await?;
@@ -94,7 +94,7 @@ pub async fn node_status(
     node: Option<String>,
     audit: Arc<AuditLogger>,
 ) -> Result<String> {
-    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let host = host.map_or_else(|| default_proxmox_host(&manager), Ok)?;
     let result: Result<String> = async {
         let client = manager.get_proxmox(&host)?;
         let node_name = client.resolve_node(node.as_deref()).await?;
@@ -218,7 +218,7 @@ pub async fn vm_list(
     vm_type: Option<String>,
     audit: Arc<AuditLogger>,
 ) -> Result<String> {
-    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let host = host.map_or_else(|| default_proxmox_host(&manager), Ok)?;
     let result: Result<String> = async {
         let client = manager.get_proxmox(&host)?;
         let node_name = client.resolve_node(node.as_deref()).await?;
@@ -320,7 +320,7 @@ pub async fn vm_status(
     vm_type: Option<String>,
     audit: Arc<AuditLogger>,
 ) -> Result<String> {
-    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let host = host.map_or_else(|| default_proxmox_host(&manager), Ok)?;
     let result: Result<String> = async {
         let client = manager.get_proxmox(&host)?;
         let node_name = client.resolve_node(node.as_deref()).await?;
@@ -421,7 +421,7 @@ pub async fn vm_start(
     dry_run: Option<bool>,
     audit: Arc<AuditLogger>,
 ) -> Result<String> {
-    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let host = host.map_or_else(|| default_proxmox_host(&manager), Ok)?;
     let vm_type = vm_type.unwrap_or_else(|| "qemu".to_string());
 
     ensure_vm_type(&vm_type)?;
@@ -451,7 +451,7 @@ pub async fn vm_start(
 
         if let Some(upid) = response.as_str() {
             let result = client
-                .wait_for_task(&node_name, upid, TASK_WAIT_TIMEOUT_SECS)
+                .wait_for_task(&node_name, upid, task_wait_timeout_secs(&manager, &host))
                 .await?;
             Ok(format!(
                 "Started {} {} on node '{}'. {}",
@@ -499,7 +499,7 @@ pub async fn vm_stop(
     dry_run: Option<bool>,
     audit: Arc<AuditLogger>,
 ) -> Result<String> {
-    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let host = host.map_or_else(|| default_proxmox_host(&manager), Ok)?;
     let vm_type = vm_type.unwrap_or_else(|| "qemu".to_string());
 
     ensure_vm_type(&vm_type)?;
@@ -568,7 +568,7 @@ pub async fn vm_stop_confirmed(
 
         if let Some(upid) = response.as_str() {
             let result = client
-                .wait_for_task(&node_name, upid, TASK_WAIT_TIMEOUT_SECS)
+                .wait_for_task(&node_name, upid, task_wait_timeout_secs(&manager, &host))
                 .await?;
             Ok(format!(
                 "Stopped {} {} on node '{}'. {}",
@@ -620,7 +620,7 @@ pub async fn vm_create(
     dry_run: Option<bool>,
     audit: Arc<AuditLogger>,
 ) -> Result<String> {
-    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let host = host.map_or_else(|| default_proxmox_host(&manager), Ok)?;
     let vm_type = vm_type.unwrap_or_else(|| "qemu".to_string());
 
     ensure_vm_type(&vm_type)?;
@@ -791,7 +791,7 @@ pub async fn vm_create_confirmed(
 
         if let Some(upid) = response.as_str() {
             let result = client
-                .wait_for_task(&node_name, upid, TASK_WAIT_TIMEOUT_SECS)
+                .wait_for_task(&node_name, upid, task_wait_timeout_secs(&manager, &host))
                 .await?;
             Ok(format!(
                 "Created {} {} on node '{}'. {}",
@@ -841,7 +841,7 @@ pub async fn vm_clone(
     dry_run: Option<bool>,
     audit: Arc<AuditLogger>,
 ) -> Result<String> {
-    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let host = host.map_or_else(|| default_proxmox_host(&manager), Ok)?;
 
     if dry_run.unwrap_or(false) {
         let output = format!(
@@ -895,7 +895,7 @@ pub async fn vm_clone(
 
         if let Some(upid) = response.as_str() {
             let result = client
-                .wait_for_task(&node_name, upid, TASK_WAIT_TIMEOUT_SECS)
+                .wait_for_task(&node_name, upid, task_wait_timeout_secs(&manager, &host))
                 .await?;
             Ok(format!(
                 "Cloned VM {} to {} on node '{}'. {}\n{}",
@@ -950,7 +950,7 @@ pub async fn vm_delete(
     dry_run: Option<bool>,
     audit: Arc<AuditLogger>,
 ) -> Result<String> {
-    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let host = host.map_or_else(|| default_proxmox_host(&manager), Ok)?;
     let vm_type = vm_type.unwrap_or_else(|| "qemu".to_string());
 
     ensure_vm_type(&vm_type)?;
@@ -1033,7 +1033,7 @@ pub async fn vm_delete_confirmed(
 
         if let Some(upid) = response.as_str() {
             let result = client
-                .wait_for_task(&node_name, upid, TASK_WAIT_TIMEOUT_SECS)
+                .wait_for_task(&node_name, upid, task_wait_timeout_secs(&manager, &host))
                 .await?;
             Ok(format!(
                 "Deleted {} {} on node '{}'. {}",
@@ -1084,7 +1084,7 @@ pub async fn snapshot_list(
     vm_type: Option<String>,
     audit: Arc<AuditLogger>,
 ) -> Result<String> {
-    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let host = host.map_or_else(|| default_proxmox_host(&manager), Ok)?;
     let result: Result<String> = async {
         let client = manager.get_proxmox(&host)?;
         let node_name = client.resolve_node(node.as_deref()).await?;
@@ -1189,7 +1189,7 @@ pub async fn snapshot_create(
     dry_run: Option<bool>,
     audit: Arc<AuditLogger>,
 ) -> Result<String> {
-    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let host = host.map_or_else(|| default_proxmox_host(&manager), Ok)?;
     let vm_type = vm_type.unwrap_or_else(|| "qemu".to_string());
 
     ensure_vm_type(&vm_type)?;
@@ -1232,7 +1232,7 @@ pub async fn snapshot_create(
 
         if let Some(upid) = response.as_str() {
             let result = client
-                .wait_for_task(&node_name, upid, TASK_WAIT_TIMEOUT_SECS)
+                .wait_for_task(&node_name, upid, task_wait_timeout_secs(&manager, &host))
                 .await?;
             Ok(format!(
                 "Created snapshot '{}' for {} {} on node '{}'. {}",
@@ -1286,7 +1286,7 @@ pub async fn snapshot_rollback(
     dry_run: Option<bool>,
     audit: Arc<AuditLogger>,
 ) -> Result<String> {
-    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let host = host.map_or_else(|| default_proxmox_host(&manager), Ok)?;
     let vm_type = vm_type.unwrap_or_else(|| "qemu".to_string());
 
     ensure_vm_type(&vm_type)?;
@@ -1368,7 +1368,7 @@ pub async fn snapshot_rollback_confirmed(
 
         if let Some(upid) = response.as_str() {
             let result = client
-                .wait_for_task(&node_name, upid, TASK_WAIT_TIMEOUT_SECS)
+                .wait_for_task(&node_name, upid, task_wait_timeout_secs(&manager, &host))
                 .await?;
             Ok(format!(
                 "Rolled back {} {} to snapshot '{}' on node '{}'. {}",
@@ -1420,7 +1420,7 @@ pub async fn storage_list(
     node: Option<String>,
     audit: Arc<AuditLogger>,
 ) -> Result<String> {
-    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let host = host.map_or_else(|| default_proxmox_host(&manager), Ok)?;
     let result: Result<String> = async {
         let client = manager.get_proxmox(&host)?;
         let node_name = client.resolve_node(node.as_deref()).await?;
@@ -1504,7 +1504,7 @@ pub async fn network_list(
     node: Option<String>,
     audit: Arc<AuditLogger>,
 ) -> Result<String> {
-    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let host = host.map_or_else(|| default_proxmox_host(&manager), Ok)?;
     let result: Result<String> = async {
         let client = manager.get_proxmox(&host)?;
         let node_name = client.resolve_node(node.as_deref()).await?;
@@ -1573,15 +1573,35 @@ pub async fn network_list(
     }
 }
 
-fn default_proxmox_host(manager: &ConnectionManager) -> String {
+pub(crate) fn default_proxmox_host(manager: &ConnectionManager) -> Result<String> {
+    let hosts = &manager.config().proxmox.hosts;
+
+    match hosts.len() {
+        0 => Err(anyhow!("No Proxmox hosts are configured.")),
+        1 => hosts
+            .keys()
+            .next()
+            .cloned()
+            .ok_or_else(|| anyhow!("No Proxmox hosts are configured.")),
+        _ => {
+            let mut host_names = hosts.keys().cloned().collect::<Vec<_>>();
+            host_names.sort();
+            Err(anyhow!(
+                "Multiple Proxmox hosts are configured ({}). Pass 'host' explicitly.",
+                host_names.join(", ")
+            ))
+        }
+    }
+}
+
+fn task_wait_timeout_secs(manager: &ConnectionManager, host: &str) -> u64 {
     manager
         .config()
         .proxmox
         .hosts
-        .keys()
-        .next()
-        .cloned()
-        .unwrap_or_else(|| "default".to_string())
+        .get(host)
+        .map(|host| host.task_wait_timeout_secs)
+        .unwrap_or(DEFAULT_TASK_WAIT_TIMEOUT_SECS)
 }
 
 fn ensure_vm_type(vm_type: &str) -> Result<()> {

--- a/src/tools/proxmox.rs
+++ b/src/tools/proxmox.rs
@@ -497,6 +497,7 @@ pub async fn vm_start(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn vm_stop(
     manager: Arc<ConnectionManager>,
     confirmation: Arc<ConfirmationManager>,
@@ -876,6 +877,7 @@ pub async fn vm_create_confirmed(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn vm_clone(
     manager: Arc<ConnectionManager>,
     host: Option<String>,
@@ -1016,6 +1018,7 @@ pub async fn vm_clone(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn vm_delete(
     manager: Arc<ConnectionManager>,
     confirmation: Arc<ConfirmationManager>,
@@ -1254,6 +1257,7 @@ pub async fn snapshot_list(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn snapshot_create(
     manager: Arc<ConnectionManager>,
     host: Option<String>,
@@ -1352,6 +1356,7 @@ pub async fn snapshot_create(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn snapshot_rollback(
     manager: Arc<ConnectionManager>,
     confirmation: Arc<ConfirmationManager>,

--- a/src/tools/proxmox.rs
+++ b/src/tools/proxmox.rs
@@ -1,0 +1,1675 @@
+use anyhow::{Result, anyhow};
+use serde_json::Value;
+use std::sync::Arc;
+
+use crate::audit::AuditLogger;
+use crate::confirmation::ConfirmationManager;
+use crate::connection::{ConnectionManager, ProxmoxClient};
+use crate::tools::{truncate_output, wrap_output_envelope};
+
+const OUTPUT_MAX_CHARS: usize = 10_000;
+const TASK_WAIT_TIMEOUT_SECS: u64 = 120;
+
+pub async fn node_list(
+    manager: Arc<ConnectionManager>,
+    host: Option<String>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let result: Result<String> = async {
+        let client = manager.get_proxmox(&host)?;
+        let nodes = client.get("/nodes").await?;
+
+        let nodes = nodes
+            .as_array()
+            .ok_or_else(|| anyhow!("Unexpected response format from /nodes"))?;
+
+        if nodes.is_empty() {
+            return Ok("No nodes found.".to_string());
+        }
+
+        let mut lines = vec![format!(
+            "Proxmox host: {}\n\n{:<16}  {:<10}  {:<8}  {:<8}  {:<12}  {}",
+            host, "NODE", "STATUS", "CPU", "MEM %", "UPTIME", "PVE VERSION"
+        )];
+
+        for node in nodes {
+            let name = node.get("node").and_then(Value::as_str).unwrap_or("?");
+            let status = node.get("status").and_then(Value::as_str).unwrap_or("?");
+            let cpu = node.get("cpu").and_then(Value::as_f64).unwrap_or(0.0);
+            let maxmem = node.get("maxmem").and_then(Value::as_u64).unwrap_or(1);
+            let mem = node.get("mem").and_then(Value::as_u64).unwrap_or(0);
+            let mem_pct = if maxmem > 0 {
+                (mem as f64 / maxmem as f64) * 100.0
+            } else {
+                0.0
+            };
+            let uptime = node.get("uptime").and_then(Value::as_u64).unwrap_or(0);
+            let pve_version = node
+                .get("pveversion")
+                .and_then(Value::as_str)
+                .unwrap_or("?");
+
+            lines.push(format!(
+                "{:<16}  {:<10}  {:<8.1}%  {:<8.1}%  {:<12}  {}",
+                name,
+                status,
+                cpu * 100.0,
+                mem_pct,
+                format_uptime(uptime),
+                pve_version
+            ));
+        }
+
+        Ok(truncate_output(&lines.join("\n"), OUTPUT_MAX_CHARS))
+    }
+    .await;
+
+    match result {
+        Ok(output) => {
+            audit
+                .log("proxmox.node.list", &host, "success", None)
+                .await
+                .ok();
+            Ok(wrap_output_envelope("proxmox.node.list", &output))
+        }
+        Err(error) => {
+            audit
+                .log(
+                    "proxmox.node.list",
+                    &host,
+                    "error",
+                    Some(&error.to_string()),
+                )
+                .await
+                .ok();
+            Err(error)
+        }
+    }
+}
+
+pub async fn node_status(
+    manager: Arc<ConnectionManager>,
+    host: Option<String>,
+    node: Option<String>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let result: Result<String> = async {
+        let client = manager.get_proxmox(&host)?;
+        let node_name = client.resolve_node(node.as_deref()).await?;
+        let status = client.get(&format!("/nodes/{}/status", node_name)).await?;
+
+        let cpu_model = status
+            .pointer("/cpuinfo/model")
+            .and_then(Value::as_str)
+            .unwrap_or("?");
+        let cpu_cores = status
+            .pointer("/cpuinfo/cpus")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let cpu_sockets = status
+            .pointer("/cpuinfo/sockets")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let cpu_usage = status.get("cpu").and_then(Value::as_f64).unwrap_or(0.0);
+        let mem_total = status
+            .pointer("/memory/total")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let mem_used = status
+            .pointer("/memory/used")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let mem_free = status
+            .pointer("/memory/free")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let swap_total = status
+            .pointer("/swap/total")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let swap_used = status
+            .pointer("/swap/used")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let rootfs_total = status
+            .pointer("/rootfs/total")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let rootfs_used = status
+            .pointer("/rootfs/used")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let uptime = status.get("uptime").and_then(Value::as_u64).unwrap_or(0);
+        let pve_version = status
+            .get("pveversion")
+            .and_then(Value::as_str)
+            .unwrap_or("?");
+        let kernel = status
+            .get("kversion")
+            .and_then(Value::as_str)
+            .unwrap_or("?");
+
+        let output = format!(
+            "Node: {} (Proxmox host: {})\n\
+             PVE Version: {}\n\
+             Kernel: {}\n\
+             Uptime: {}\n\n\
+             CPU: {} ({} sockets, {} cores)\n\
+             CPU Usage: {:.1}%\n\
+             Load Average: {}\n\n\
+             Memory: {} / {} ({:.1}% used)\n\
+             Free: {}\n\
+             Swap: {} / {}\n\n\
+             Root FS: {} / {} ({:.1}% used)",
+            node_name,
+            host,
+            pve_version,
+            kernel,
+            format_uptime(uptime),
+            cpu_model,
+            cpu_sockets,
+            cpu_cores,
+            cpu_usage * 100.0,
+            format_loadavg(status.get("loadavg")),
+            format_bytes(mem_used),
+            format_bytes(mem_total),
+            percent(mem_used, mem_total),
+            format_bytes(mem_free),
+            format_bytes(swap_used),
+            format_bytes(swap_total),
+            format_bytes(rootfs_used),
+            format_bytes(rootfs_total),
+            percent(rootfs_used, rootfs_total),
+        );
+
+        Ok(output)
+    }
+    .await;
+
+    match result {
+        Ok(output) => {
+            audit
+                .log("proxmox.node.status", &host, "success", None)
+                .await
+                .ok();
+            Ok(wrap_output_envelope("proxmox.node.status", &output))
+        }
+        Err(error) => {
+            audit
+                .log(
+                    "proxmox.node.status",
+                    &host,
+                    "error",
+                    Some(&error.to_string()),
+                )
+                .await
+                .ok();
+            Err(error)
+        }
+    }
+}
+
+pub async fn vm_list(
+    manager: Arc<ConnectionManager>,
+    host: Option<String>,
+    node: Option<String>,
+    vm_type: Option<String>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let result: Result<String> = async {
+        let client = manager.get_proxmox(&host)?;
+        let node_name = client.resolve_node(node.as_deref()).await?;
+        let filter_type = vm_type.as_deref();
+
+        if let Some(filter_type) = filter_type {
+            ensure_vm_type(filter_type)?;
+        }
+
+        let mut all_vms: Vec<Value> = Vec::new();
+
+        if filter_type.is_none() || filter_type == Some("qemu") {
+            let qemu = client.get(&format!("/nodes/{}/qemu", node_name)).await?;
+            if let Some(items) = qemu.as_array() {
+                for mut vm in items.clone() {
+                    if let Some(object) = vm.as_object_mut() {
+                        object.insert("type".to_string(), Value::String("qemu".to_string()));
+                    }
+                    all_vms.push(vm);
+                }
+            }
+        }
+
+        if filter_type.is_none() || filter_type == Some("lxc") {
+            let lxc = client.get(&format!("/nodes/{}/lxc", node_name)).await?;
+            if let Some(items) = lxc.as_array() {
+                for mut vm in items.clone() {
+                    if let Some(object) = vm.as_object_mut() {
+                        object.insert("type".to_string(), Value::String("lxc".to_string()));
+                    }
+                    all_vms.push(vm);
+                }
+            }
+        }
+
+        if all_vms.is_empty() {
+            return Ok(format!("No VMs/CTs found on node '{}'.", node_name));
+        }
+
+        all_vms.sort_by_key(|vm| vm.get("vmid").and_then(Value::as_u64).unwrap_or(0));
+
+        let mut lines = vec![format!(
+            "Node: {} (Proxmox host: {})\n\n{:<8}  {:<6}  {:<24}  {:<10}  {:<6}  {:<10}  {}",
+            node_name, host, "VMID", "TYPE", "NAME", "STATUS", "CPU", "MEM", "UPTIME"
+        )];
+
+        for vm in &all_vms {
+            let vmid = vm.get("vmid").and_then(Value::as_u64).unwrap_or(0);
+            let vm_type = vm.get("type").and_then(Value::as_str).unwrap_or("?");
+            let name = vm.get("name").and_then(Value::as_str).unwrap_or("?");
+            let status = vm.get("status").and_then(Value::as_str).unwrap_or("?");
+            let cpus = vm.get("cpus").and_then(Value::as_u64).unwrap_or(0);
+            let maxmem = vm.get("maxmem").and_then(Value::as_u64).unwrap_or(0);
+            let uptime = vm.get("uptime").and_then(Value::as_u64).unwrap_or(0);
+
+            lines.push(format!(
+                "{:<8}  {:<6}  {:<24}  {:<10}  {:<6}  {:<10}  {}",
+                vmid,
+                vm_type,
+                name,
+                status,
+                cpus,
+                format_bytes(maxmem),
+                if uptime > 0 {
+                    format_uptime(uptime)
+                } else {
+                    "-".to_string()
+                }
+            ));
+        }
+
+        Ok(truncate_output(&lines.join("\n"), OUTPUT_MAX_CHARS))
+    }
+    .await;
+
+    match result {
+        Ok(output) => {
+            audit
+                .log("proxmox.vm.list", &host, "success", None)
+                .await
+                .ok();
+            Ok(wrap_output_envelope("proxmox.vm.list", &output))
+        }
+        Err(error) => {
+            audit
+                .log("proxmox.vm.list", &host, "error", Some(&error.to_string()))
+                .await
+                .ok();
+            Err(error)
+        }
+    }
+}
+
+pub async fn vm_status(
+    manager: Arc<ConnectionManager>,
+    host: Option<String>,
+    node: Option<String>,
+    vmid: u64,
+    vm_type: Option<String>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let result: Result<String> = async {
+        let client = manager.get_proxmox(&host)?;
+        let node_name = client.resolve_node(node.as_deref()).await?;
+        let vm_type = resolved_vm_type(vm_type.as_deref())?;
+        let path = format!("/nodes/{}/{}/{}/status/current", node_name, vm_type, vmid);
+        let status = client.get(&path).await?;
+
+        let name = status.get("name").and_then(Value::as_str).unwrap_or("?");
+        let vm_status = status.get("status").and_then(Value::as_str).unwrap_or("?");
+        let cpus = status.get("cpus").and_then(Value::as_u64).unwrap_or(0);
+        let cpu_usage = status.get("cpu").and_then(Value::as_f64).unwrap_or(0.0);
+        let maxmem = status.get("maxmem").and_then(Value::as_u64).unwrap_or(0);
+        let mem = status.get("mem").and_then(Value::as_u64).unwrap_or(0);
+        let maxdisk = status.get("maxdisk").and_then(Value::as_u64).unwrap_or(0);
+        let disk = status.get("disk").and_then(Value::as_u64).unwrap_or(0);
+        let uptime = status.get("uptime").and_then(Value::as_u64).unwrap_or(0);
+        let netin = status.get("netin").and_then(Value::as_u64).unwrap_or(0);
+        let netout = status.get("netout").and_then(Value::as_u64).unwrap_or(0);
+        let pid = status.get("pid").and_then(Value::as_u64);
+        let qmpstatus = status.get("qmpstatus").and_then(Value::as_str);
+
+        let mut output = format!(
+            "VM/CT {} ({}) on node {} (Proxmox host: {})\n\n\
+             Name: {}\n\
+             Type: {}\n\
+             Status: {}{}\n\
+             Uptime: {}\n\n\
+             CPU: {} cores, {:.1}% usage\n\
+             Memory: {} / {} ({:.1}% used)\n\
+             Disk: {} / {} ({:.1}% used)\n\n\
+             Network In: {}\n\
+             Network Out: {}",
+            vmid,
+            vm_type,
+            node_name,
+            host,
+            name,
+            vm_type,
+            vm_status,
+            qmpstatus
+                .map(|status| format!(" (QMP: {})", status))
+                .unwrap_or_default(),
+            format_uptime(uptime),
+            cpus,
+            cpu_usage * 100.0,
+            format_bytes(mem),
+            format_bytes(maxmem),
+            percent(mem, maxmem),
+            format_bytes(disk),
+            format_bytes(maxdisk),
+            percent(disk, maxdisk),
+            format_bytes(netin),
+            format_bytes(netout),
+        );
+
+        if let Some(pid) = pid {
+            output.push_str(&format!("\nPID: {}", pid));
+        }
+
+        Ok(output)
+    }
+    .await;
+
+    match result {
+        Ok(output) => {
+            audit
+                .log(
+                    "proxmox.vm.status",
+                    &host,
+                    "success",
+                    Some(&vmid.to_string()),
+                )
+                .await
+                .ok();
+            Ok(wrap_output_envelope("proxmox.vm.status", &output))
+        }
+        Err(error) => {
+            audit
+                .log(
+                    "proxmox.vm.status",
+                    &host,
+                    "error",
+                    Some(&error.to_string()),
+                )
+                .await
+                .ok();
+            Err(error)
+        }
+    }
+}
+
+pub async fn vm_start(
+    manager: Arc<ConnectionManager>,
+    host: Option<String>,
+    node: Option<String>,
+    vmid: u64,
+    vm_type: Option<String>,
+    dry_run: Option<bool>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let vm_type = vm_type.unwrap_or_else(|| "qemu".to_string());
+
+    ensure_vm_type(&vm_type)?;
+
+    if dry_run.unwrap_or(false) {
+        let output = format!(
+            "DRY RUN: Would start {} {} on Proxmox host '{}'.",
+            vm_type, vmid, host
+        );
+        audit
+            .log(
+                "proxmox.vm.start",
+                &host,
+                "dry_run",
+                Some(&vmid.to_string()),
+            )
+            .await
+            .ok();
+        return Ok(wrap_output_envelope("proxmox.vm.start", &output));
+    }
+
+    let result: Result<String> = async {
+        let client = manager.get_proxmox(&host)?;
+        let node_name = client.resolve_node(node.as_deref()).await?;
+        let path = format!("/nodes/{}/{}/{}/status/start", node_name, vm_type, vmid);
+        let response = client.post(&path, &[]).await?;
+
+        if let Some(upid) = response.as_str() {
+            let result = client
+                .wait_for_task(&node_name, upid, TASK_WAIT_TIMEOUT_SECS)
+                .await?;
+            Ok(format!(
+                "Started {} {} on node '{}'. {}",
+                vm_type, vmid, node_name, result
+            ))
+        } else {
+            Ok(format!(
+                "Started {} {} on node '{}'.",
+                vm_type, vmid, node_name
+            ))
+        }
+    }
+    .await;
+
+    match result {
+        Ok(output) => {
+            audit
+                .log(
+                    "proxmox.vm.start",
+                    &host,
+                    "success",
+                    Some(&vmid.to_string()),
+                )
+                .await
+                .ok();
+            Ok(wrap_output_envelope("proxmox.vm.start", &output))
+        }
+        Err(error) => {
+            audit
+                .log("proxmox.vm.start", &host, "error", Some(&error.to_string()))
+                .await
+                .ok();
+            Err(error)
+        }
+    }
+}
+
+pub async fn vm_stop(
+    manager: Arc<ConnectionManager>,
+    confirmation: Arc<ConfirmationManager>,
+    host: Option<String>,
+    node: Option<String>,
+    vmid: u64,
+    vm_type: Option<String>,
+    dry_run: Option<bool>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let vm_type = vm_type.unwrap_or_else(|| "qemu".to_string());
+
+    ensure_vm_type(&vm_type)?;
+
+    if dry_run.unwrap_or(false) {
+        let output = format!(
+            "DRY RUN: Would stop {} {} on Proxmox host '{}'.",
+            vm_type, vmid, host
+        );
+        audit
+            .log("proxmox.vm.stop", &host, "dry_run", Some(&vmid.to_string()))
+            .await
+            .ok();
+        return Ok(wrap_output_envelope("proxmox.vm.stop", &output));
+    }
+
+    let params_json = serde_json::json!({
+        "host": host.clone(),
+        "node": node.clone(),
+        "vmid": vmid,
+        "vm_type": vm_type.clone(),
+    })
+    .to_string();
+
+    if let Some(response) = confirmation
+        .check_and_maybe_require(
+            "proxmox.vm.stop",
+            None,
+            &format!(
+                "About to STOP {} {} on Proxmox host '{}'. The VM/CT will be shut down.",
+                vm_type, vmid, host
+            ),
+            &params_json,
+        )
+        .await?
+    {
+        audit
+            .log(
+                "proxmox.vm.stop",
+                &host,
+                "confirmation_required",
+                Some(&vmid.to_string()),
+            )
+            .await
+            .ok();
+        return Ok(response);
+    }
+
+    vm_stop_confirmed(manager, host, node, vmid, Some(vm_type), audit).await
+}
+
+pub async fn vm_stop_confirmed(
+    manager: Arc<ConnectionManager>,
+    host: String,
+    node: Option<String>,
+    vmid: u64,
+    vm_type: Option<String>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let result: Result<String> = async {
+        let client = manager.get_proxmox(&host)?;
+        let node_name = client.resolve_node(node.as_deref()).await?;
+        let vm_type = resolved_vm_type(vm_type.as_deref())?;
+        let path = format!("/nodes/{}/{}/{}/status/shutdown", node_name, vm_type, vmid);
+        let response = client.post(&path, &[]).await?;
+
+        if let Some(upid) = response.as_str() {
+            let result = client
+                .wait_for_task(&node_name, upid, TASK_WAIT_TIMEOUT_SECS)
+                .await?;
+            Ok(format!(
+                "Stopped {} {} on node '{}'. {}",
+                vm_type, vmid, node_name, result
+            ))
+        } else {
+            Ok(format!(
+                "Stop requested for {} {} on node '{}'.",
+                vm_type, vmid, node_name
+            ))
+        }
+    }
+    .await;
+
+    match result {
+        Ok(output) => {
+            audit
+                .log("proxmox.vm.stop", &host, "success", Some(&vmid.to_string()))
+                .await
+                .ok();
+            Ok(wrap_output_envelope("proxmox.vm.stop", &output))
+        }
+        Err(error) => {
+            audit
+                .log("proxmox.vm.stop", &host, "error", Some(&error.to_string()))
+                .await
+                .ok();
+            Err(error)
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn vm_create(
+    manager: Arc<ConnectionManager>,
+    confirmation: Arc<ConfirmationManager>,
+    host: Option<String>,
+    node: Option<String>,
+    vmid: Option<u64>,
+    vm_type: Option<String>,
+    name: Option<String>,
+    cores: Option<u64>,
+    memory: Option<u64>,
+    ostype: Option<String>,
+    iso: Option<String>,
+    storage: Option<String>,
+    disk_size: Option<String>,
+    net: Option<String>,
+    dry_run: Option<bool>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let vm_type = vm_type.unwrap_or_else(|| "qemu".to_string());
+
+    ensure_vm_type(&vm_type)?;
+
+    let mut param_lines = vec![format!("Type: {}", vm_type)];
+    if let Some(vmid) = vmid {
+        param_lines.push(format!("VMID: {}", vmid));
+    }
+    if let Some(name) = &name {
+        param_lines.push(format!("Name: {}", name));
+    }
+    if let Some(cores) = cores {
+        param_lines.push(format!("Cores: {}", cores));
+    }
+    if let Some(memory) = memory {
+        param_lines.push(format!("Memory: {} MB", memory));
+    }
+    if let Some(ostype) = &ostype {
+        param_lines.push(format!("OS Type: {}", ostype));
+    }
+    if let Some(iso) = &iso {
+        param_lines.push(format!("ISO: {}", iso));
+    }
+    if let Some(storage) = &storage {
+        param_lines.push(format!("Storage: {}", storage));
+    }
+    if let Some(disk_size) = &disk_size {
+        param_lines.push(format!("Disk: {}", disk_size));
+    }
+    if let Some(net) = &net {
+        param_lines.push(format!("Network: {}", net));
+    }
+
+    if dry_run.unwrap_or(false) {
+        let output = format!(
+            "DRY RUN: Would create {} on Proxmox host '{}':\n{}",
+            vm_type,
+            host,
+            param_lines.join("\n")
+        );
+        audit
+            .log("proxmox.vm.create", &host, "dry_run", name.as_deref())
+            .await
+            .ok();
+        return Ok(wrap_output_envelope("proxmox.vm.create", &output));
+    }
+
+    let params_json = serde_json::json!({
+        "host": host.clone(),
+        "node": node.clone(),
+        "vmid": vmid,
+        "vm_type": vm_type.clone(),
+        "name": name.clone(),
+        "cores": cores,
+        "memory": memory,
+        "ostype": ostype.clone(),
+        "iso": iso.clone(),
+        "storage": storage.clone(),
+        "disk_size": disk_size.clone(),
+        "net": net.clone(),
+    })
+    .to_string();
+
+    if let Some(response) = confirmation
+        .check_and_maybe_require(
+            "proxmox.vm.create",
+            None,
+            &format!(
+                "About to CREATE a new {} on Proxmox host '{}':\n{}",
+                vm_type,
+                host,
+                param_lines.join("\n")
+            ),
+            &params_json,
+        )
+        .await?
+    {
+        audit
+            .log(
+                "proxmox.vm.create",
+                &host,
+                "confirmation_required",
+                name.as_deref(),
+            )
+            .await
+            .ok();
+        return Ok(response);
+    }
+
+    vm_create_confirmed(
+        manager, host, node, vmid, vm_type, name, cores, memory, ostype, iso, storage, disk_size,
+        net, audit,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn vm_create_confirmed(
+    manager: Arc<ConnectionManager>,
+    host: String,
+    node: Option<String>,
+    vmid: Option<u64>,
+    vm_type: String,
+    name: Option<String>,
+    cores: Option<u64>,
+    memory: Option<u64>,
+    ostype: Option<String>,
+    iso: Option<String>,
+    storage: Option<String>,
+    disk_size: Option<String>,
+    net: Option<String>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let result: Result<String> = async {
+        let client = manager.get_proxmox(&host)?;
+        let node_name = client.resolve_node(node.as_deref()).await?;
+        let vm_type = resolved_vm_type(Some(&vm_type))?;
+        let vmid = match vmid {
+            Some(vmid) => vmid,
+            None => next_vmid(&client).await?,
+        };
+
+        let mut params: Vec<(&str, String)> = vec![("vmid", vmid.to_string())];
+
+        if let Some(name) = &name {
+            params.push(("name", name.clone()));
+        }
+        if let Some(cores) = cores {
+            params.push(("cores", cores.to_string()));
+        }
+        if let Some(memory) = memory {
+            params.push(("memory", memory.to_string()));
+        }
+
+        if vm_type == "qemu" {
+            if let Some(ostype) = &ostype {
+                params.push(("ostype", ostype.clone()));
+            }
+            if let Some(iso) = &iso {
+                params.push(("ide2", format!("{},media=cdrom", iso)));
+            }
+            if let Some(storage) = &storage {
+                let size = disk_size.as_deref().unwrap_or("32G");
+                params.push(("scsi0", format!("{}:{}", storage, size)));
+            }
+            if let Some(net) = &net {
+                params.push(("net0", net.clone()));
+            }
+        } else {
+            if let Some(ostype) = &ostype {
+                params.push(("ostemplate", ostype.clone()));
+            }
+            if let Some(storage) = &storage {
+                let size = disk_size.as_deref().unwrap_or("8");
+                params.push(("rootfs", format!("{}:{}", storage, size)));
+            }
+            if let Some(net) = &net {
+                params.push(("net0", net.clone()));
+            }
+        }
+
+        let param_refs: Vec<(&str, &str)> = params
+            .iter()
+            .map(|(key, value)| (*key, value.as_str()))
+            .collect();
+        let path = format!("/nodes/{}/{}", node_name, vm_type);
+        let response = client.post(&path, &param_refs).await?;
+
+        if let Some(upid) = response.as_str() {
+            let result = client
+                .wait_for_task(&node_name, upid, TASK_WAIT_TIMEOUT_SECS)
+                .await?;
+            Ok(format!(
+                "Created {} {} on node '{}'. {}",
+                vm_type, vmid, node_name, result
+            ))
+        } else {
+            Ok(format!(
+                "Created {} {} on node '{}'.",
+                vm_type, vmid, node_name
+            ))
+        }
+    }
+    .await;
+
+    match result {
+        Ok(output) => {
+            audit
+                .log("proxmox.vm.create", &host, "success", name.as_deref())
+                .await
+                .ok();
+            Ok(wrap_output_envelope("proxmox.vm.create", &output))
+        }
+        Err(error) => {
+            audit
+                .log(
+                    "proxmox.vm.create",
+                    &host,
+                    "error",
+                    Some(&error.to_string()),
+                )
+                .await
+                .ok();
+            Err(error)
+        }
+    }
+}
+
+pub async fn vm_clone(
+    manager: Arc<ConnectionManager>,
+    host: Option<String>,
+    node: Option<String>,
+    vmid: u64,
+    newid: Option<u64>,
+    name: Option<String>,
+    full: Option<bool>,
+    target_storage: Option<String>,
+    dry_run: Option<bool>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+
+    if dry_run.unwrap_or(false) {
+        let output = format!(
+            "DRY RUN: Would clone VM {} to new VM{} on Proxmox host '{}'.\n\
+             Full clone: {}\n{}",
+            vmid,
+            newid.map(|id| format!(" {}", id)).unwrap_or_default(),
+            host,
+            full.unwrap_or(true),
+            name.as_ref()
+                .map(|name| format!("Name: {}", name))
+                .unwrap_or_default(),
+        );
+        audit
+            .log(
+                "proxmox.vm.clone",
+                &host,
+                "dry_run",
+                Some(&vmid.to_string()),
+            )
+            .await
+            .ok();
+        return Ok(wrap_output_envelope("proxmox.vm.clone", &output));
+    }
+
+    let result: Result<String> = async {
+        let client = manager.get_proxmox(&host)?;
+        let node_name = client.resolve_node(node.as_deref()).await?;
+        let newid = match newid {
+            Some(newid) => newid,
+            None => next_vmid(&client).await?,
+        };
+
+        let mut params: Vec<(&str, String)> = vec![("newid", newid.to_string())];
+        if let Some(name) = &name {
+            params.push(("name", name.clone()));
+        }
+        if let Some(full) = full {
+            params.push(("full", bool_to_proxmox(full).to_string()));
+        }
+        if let Some(target_storage) = &target_storage {
+            params.push(("storage", target_storage.clone()));
+        }
+
+        let param_refs: Vec<(&str, &str)> = params
+            .iter()
+            .map(|(key, value)| (*key, value.as_str()))
+            .collect();
+        let path = format!("/nodes/{}/qemu/{}/clone", node_name, vmid);
+        let response = client.post(&path, &param_refs).await?;
+
+        if let Some(upid) = response.as_str() {
+            let result = client
+                .wait_for_task(&node_name, upid, TASK_WAIT_TIMEOUT_SECS)
+                .await?;
+            Ok(format!(
+                "Cloned VM {} to {} on node '{}'. {}\n{}",
+                vmid,
+                newid,
+                node_name,
+                result,
+                name.as_ref()
+                    .map(|name| format!("Name: {}", name))
+                    .unwrap_or_default(),
+            ))
+        } else {
+            Ok(format!(
+                "Clone requested for VM {} to {} on node '{}'.",
+                vmid, newid, node_name
+            ))
+        }
+    }
+    .await;
+
+    match result {
+        Ok(output) => {
+            audit
+                .log(
+                    "proxmox.vm.clone",
+                    &host,
+                    "success",
+                    Some(&vmid.to_string()),
+                )
+                .await
+                .ok();
+            Ok(wrap_output_envelope("proxmox.vm.clone", &output))
+        }
+        Err(error) => {
+            audit
+                .log("proxmox.vm.clone", &host, "error", Some(&error.to_string()))
+                .await
+                .ok();
+            Err(error)
+        }
+    }
+}
+
+pub async fn vm_delete(
+    manager: Arc<ConnectionManager>,
+    confirmation: Arc<ConfirmationManager>,
+    host: Option<String>,
+    node: Option<String>,
+    vmid: u64,
+    vm_type: Option<String>,
+    purge: Option<bool>,
+    dry_run: Option<bool>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let vm_type = vm_type.unwrap_or_else(|| "qemu".to_string());
+
+    ensure_vm_type(&vm_type)?;
+
+    if dry_run.unwrap_or(false) {
+        let output = format!(
+            "DRY RUN: Would DELETE {} {} on Proxmox host '{}'. Purge: {}",
+            vm_type,
+            vmid,
+            host,
+            purge.unwrap_or(false)
+        );
+        audit
+            .log(
+                "proxmox.vm.delete",
+                &host,
+                "dry_run",
+                Some(&vmid.to_string()),
+            )
+            .await
+            .ok();
+        return Ok(wrap_output_envelope("proxmox.vm.delete", &output));
+    }
+
+    let params_json = serde_json::json!({
+        "host": host.clone(),
+        "node": node.clone(),
+        "vmid": vmid,
+        "vm_type": vm_type.clone(),
+        "purge": purge,
+    })
+    .to_string();
+
+    if let Some(response) = confirmation
+        .check_and_maybe_require(
+            "proxmox.vm.delete",
+            None,
+            &format!(
+                "About to PERMANENTLY DELETE {} {} on Proxmox host '{}'. This cannot be undone.",
+                vm_type, vmid, host
+            ),
+            &params_json,
+        )
+        .await?
+    {
+        audit
+            .log(
+                "proxmox.vm.delete",
+                &host,
+                "confirmation_required",
+                Some(&vmid.to_string()),
+            )
+            .await
+            .ok();
+        return Ok(response);
+    }
+
+    vm_delete_confirmed(manager, host, node, vmid, vm_type, purge, audit).await
+}
+
+pub async fn vm_delete_confirmed(
+    manager: Arc<ConnectionManager>,
+    host: String,
+    node: Option<String>,
+    vmid: u64,
+    vm_type: String,
+    purge: Option<bool>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let result: Result<String> = async {
+        let client = manager.get_proxmox(&host)?;
+        let node_name = client.resolve_node(node.as_deref()).await?;
+        let vm_type = resolved_vm_type(Some(&vm_type))?;
+        let mut path = format!("/nodes/{}/{}/{}", node_name, vm_type, vmid);
+        if purge.unwrap_or(false) {
+            path.push_str("?purge=1&destroy-unreferenced-disks=1");
+        }
+
+        let response = client.delete(&path).await?;
+
+        if let Some(upid) = response.as_str() {
+            let result = client
+                .wait_for_task(&node_name, upid, TASK_WAIT_TIMEOUT_SECS)
+                .await?;
+            Ok(format!(
+                "Deleted {} {} on node '{}'. {}",
+                vm_type, vmid, node_name, result
+            ))
+        } else {
+            Ok(format!(
+                "Delete requested for {} {} on node '{}'.",
+                vm_type, vmid, node_name
+            ))
+        }
+    }
+    .await;
+
+    match result {
+        Ok(output) => {
+            audit
+                .log(
+                    "proxmox.vm.delete",
+                    &host,
+                    "success",
+                    Some(&vmid.to_string()),
+                )
+                .await
+                .ok();
+            Ok(wrap_output_envelope("proxmox.vm.delete", &output))
+        }
+        Err(error) => {
+            audit
+                .log(
+                    "proxmox.vm.delete",
+                    &host,
+                    "error",
+                    Some(&error.to_string()),
+                )
+                .await
+                .ok();
+            Err(error)
+        }
+    }
+}
+
+pub async fn snapshot_list(
+    manager: Arc<ConnectionManager>,
+    host: Option<String>,
+    node: Option<String>,
+    vmid: u64,
+    vm_type: Option<String>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let result: Result<String> = async {
+        let client = manager.get_proxmox(&host)?;
+        let node_name = client.resolve_node(node.as_deref()).await?;
+        let vm_type = resolved_vm_type(vm_type.as_deref())?;
+        let path = format!("/nodes/{}/{}/{}/snapshot", node_name, vm_type, vmid);
+        let snapshots = client.get(&path).await?;
+
+        let snapshots = snapshots
+            .as_array()
+            .ok_or_else(|| anyhow!("Unexpected response format from snapshot list"))?;
+
+        if snapshots.is_empty()
+            || (snapshots.len() == 1
+                && snapshots[0].get("name").and_then(Value::as_str) == Some("current"))
+        {
+            return Ok(format!(
+                "No snapshots found for {} {} on node '{}'.",
+                vm_type, vmid, node_name
+            ));
+        }
+
+        let mut lines = vec![format!(
+            "Snapshots for {} {} on node '{}' (Proxmox host: {})\n\n{:<24}  {:<24}  {:<10}  {}",
+            vm_type, vmid, node_name, host, "NAME", "DESCRIPTION", "RAM", "PARENT"
+        )];
+
+        for snapshot in snapshots {
+            let name = snapshot.get("name").and_then(Value::as_str).unwrap_or("?");
+            if name == "current" {
+                continue;
+            }
+
+            let description = snapshot
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let snaptime = snapshot.get("snaptime").and_then(Value::as_u64);
+            let vmstate = snapshot.get("vmstate").and_then(Value::as_u64).unwrap_or(0);
+            let parent = snapshot
+                .get("parent")
+                .and_then(Value::as_str)
+                .unwrap_or("-");
+
+            let time_str = snaptime
+                .and_then(|timestamp| {
+                    chrono::DateTime::<chrono::Utc>::from_timestamp(timestamp as i64, 0)
+                })
+                .map(|datetime| datetime.format("%Y-%m-%d %H:%M:%S").to_string())
+                .unwrap_or_else(|| "?".to_string());
+
+            lines.push(format!(
+                "{:<24}  {:<24}  {:<10}  {}\n  Created: {}",
+                name,
+                truncate_cell(description, 24),
+                if vmstate > 0 { "yes" } else { "no" },
+                parent,
+                time_str,
+            ));
+        }
+
+        Ok(truncate_output(&lines.join("\n"), OUTPUT_MAX_CHARS))
+    }
+    .await;
+
+    match result {
+        Ok(output) => {
+            audit
+                .log(
+                    "proxmox.vm.snapshot.list",
+                    &host,
+                    "success",
+                    Some(&vmid.to_string()),
+                )
+                .await
+                .ok();
+            Ok(wrap_output_envelope("proxmox.vm.snapshot.list", &output))
+        }
+        Err(error) => {
+            audit
+                .log(
+                    "proxmox.vm.snapshot.list",
+                    &host,
+                    "error",
+                    Some(&error.to_string()),
+                )
+                .await
+                .ok();
+            Err(error)
+        }
+    }
+}
+
+pub async fn snapshot_create(
+    manager: Arc<ConnectionManager>,
+    host: Option<String>,
+    node: Option<String>,
+    vmid: u64,
+    vm_type: Option<String>,
+    snapname: String,
+    description: Option<String>,
+    vmstate: Option<bool>,
+    dry_run: Option<bool>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let vm_type = vm_type.unwrap_or_else(|| "qemu".to_string());
+
+    ensure_vm_type(&vm_type)?;
+
+    if dry_run.unwrap_or(false) {
+        let output = format!(
+            "DRY RUN: Would create snapshot '{}' for {} {} on Proxmox host '{}'.",
+            snapname, vm_type, vmid, host
+        );
+        audit
+            .log(
+                "proxmox.vm.snapshot.create",
+                &host,
+                "dry_run",
+                Some(&snapname),
+            )
+            .await
+            .ok();
+        return Ok(wrap_output_envelope("proxmox.vm.snapshot.create", &output));
+    }
+
+    let result: Result<String> = async {
+        let client = manager.get_proxmox(&host)?;
+        let node_name = client.resolve_node(node.as_deref()).await?;
+
+        let mut params: Vec<(&str, String)> = vec![("snapname", snapname.clone())];
+        if let Some(description) = &description {
+            params.push(("description", description.clone()));
+        }
+        if let Some(vmstate) = vmstate {
+            params.push(("vmstate", bool_to_proxmox(vmstate).to_string()));
+        }
+
+        let param_refs: Vec<(&str, &str)> = params
+            .iter()
+            .map(|(key, value)| (*key, value.as_str()))
+            .collect();
+        let path = format!("/nodes/{}/{}/{}/snapshot", node_name, vm_type, vmid);
+        let response = client.post(&path, &param_refs).await?;
+
+        if let Some(upid) = response.as_str() {
+            let result = client
+                .wait_for_task(&node_name, upid, TASK_WAIT_TIMEOUT_SECS)
+                .await?;
+            Ok(format!(
+                "Created snapshot '{}' for {} {} on node '{}'. {}",
+                snapname, vm_type, vmid, node_name, result
+            ))
+        } else {
+            Ok(format!(
+                "Snapshot '{}' created for {} {} on node '{}'.",
+                snapname, vm_type, vmid, node_name
+            ))
+        }
+    }
+    .await;
+
+    match result {
+        Ok(output) => {
+            audit
+                .log(
+                    "proxmox.vm.snapshot.create",
+                    &host,
+                    "success",
+                    Some(&snapname),
+                )
+                .await
+                .ok();
+            Ok(wrap_output_envelope("proxmox.vm.snapshot.create", &output))
+        }
+        Err(error) => {
+            audit
+                .log(
+                    "proxmox.vm.snapshot.create",
+                    &host,
+                    "error",
+                    Some(&error.to_string()),
+                )
+                .await
+                .ok();
+            Err(error)
+        }
+    }
+}
+
+pub async fn snapshot_rollback(
+    manager: Arc<ConnectionManager>,
+    confirmation: Arc<ConfirmationManager>,
+    host: Option<String>,
+    node: Option<String>,
+    vmid: u64,
+    vm_type: Option<String>,
+    snapname: String,
+    dry_run: Option<bool>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let vm_type = vm_type.unwrap_or_else(|| "qemu".to_string());
+
+    ensure_vm_type(&vm_type)?;
+
+    if dry_run.unwrap_or(false) {
+        let output = format!(
+            "DRY RUN: Would rollback {} {} to snapshot '{}' on Proxmox host '{}'.",
+            vm_type, vmid, snapname, host
+        );
+        audit
+            .log(
+                "proxmox.vm.snapshot.rollback",
+                &host,
+                "dry_run",
+                Some(&snapname),
+            )
+            .await
+            .ok();
+        return Ok(wrap_output_envelope(
+            "proxmox.vm.snapshot.rollback",
+            &output,
+        ));
+    }
+
+    let params_json = serde_json::json!({
+        "host": host.clone(),
+        "node": node.clone(),
+        "vmid": vmid,
+        "vm_type": vm_type.clone(),
+        "snapname": snapname.clone(),
+    })
+    .to_string();
+
+    if let Some(response) = confirmation
+        .check_and_maybe_require(
+            "proxmox.vm.snapshot.rollback",
+            None,
+            &format!(
+                "About to ROLLBACK {} {} to snapshot '{}' on Proxmox host '{}'. Current state will be lost.",
+                vm_type, vmid, snapname, host
+            ),
+            &params_json,
+        )
+        .await?
+    {
+        audit
+            .log(
+                "proxmox.vm.snapshot.rollback",
+                &host,
+                "confirmation_required",
+                Some(&snapname),
+            )
+            .await
+            .ok();
+        return Ok(response);
+    }
+
+    snapshot_rollback_confirmed(manager, host, node, vmid, vm_type, snapname, audit).await
+}
+
+pub async fn snapshot_rollback_confirmed(
+    manager: Arc<ConnectionManager>,
+    host: String,
+    node: Option<String>,
+    vmid: u64,
+    vm_type: String,
+    snapname: String,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let result: Result<String> = async {
+        let client = manager.get_proxmox(&host)?;
+        let node_name = client.resolve_node(node.as_deref()).await?;
+        let vm_type = resolved_vm_type(Some(&vm_type))?;
+        let path = format!(
+            "/nodes/{}/{}/{}/snapshot/{}/rollback",
+            node_name, vm_type, vmid, snapname
+        );
+        let response = client.post(&path, &[]).await?;
+
+        if let Some(upid) = response.as_str() {
+            let result = client
+                .wait_for_task(&node_name, upid, TASK_WAIT_TIMEOUT_SECS)
+                .await?;
+            Ok(format!(
+                "Rolled back {} {} to snapshot '{}' on node '{}'. {}",
+                vm_type, vmid, snapname, node_name, result
+            ))
+        } else {
+            Ok(format!(
+                "Rollback requested for {} {} to snapshot '{}' on node '{}'.",
+                vm_type, vmid, snapname, node_name
+            ))
+        }
+    }
+    .await;
+
+    match result {
+        Ok(output) => {
+            audit
+                .log(
+                    "proxmox.vm.snapshot.rollback",
+                    &host,
+                    "success",
+                    Some(&snapname),
+                )
+                .await
+                .ok();
+            Ok(wrap_output_envelope(
+                "proxmox.vm.snapshot.rollback",
+                &output,
+            ))
+        }
+        Err(error) => {
+            audit
+                .log(
+                    "proxmox.vm.snapshot.rollback",
+                    &host,
+                    "error",
+                    Some(&error.to_string()),
+                )
+                .await
+                .ok();
+            Err(error)
+        }
+    }
+}
+
+pub async fn storage_list(
+    manager: Arc<ConnectionManager>,
+    host: Option<String>,
+    node: Option<String>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let result: Result<String> = async {
+        let client = manager.get_proxmox(&host)?;
+        let node_name = client.resolve_node(node.as_deref()).await?;
+        let storage = client.get(&format!("/nodes/{}/storage", node_name)).await?;
+
+        let storage = storage
+            .as_array()
+            .ok_or_else(|| anyhow!("Unexpected response format from storage list"))?;
+
+        if storage.is_empty() {
+            return Ok(format!("No storage pools found on node '{}'.", node_name));
+        }
+
+        let mut lines = vec![format!(
+            "Storage on node '{}' (Proxmox host: {})\n\n{:<20}  {:<10}  {:<10}  {:<12}  {:<12}  {:<8}  {}",
+            node_name,
+            host,
+            "STORAGE",
+            "TYPE",
+            "STATUS",
+            "USED",
+            "TOTAL",
+            "USE%",
+            "CONTENT"
+        )];
+
+        for pool in storage {
+            let name = pool.get("storage").and_then(Value::as_str).unwrap_or("?");
+            let pool_type = pool.get("type").and_then(Value::as_str).unwrap_or("?");
+            let active = pool.get("active").and_then(Value::as_u64).unwrap_or(0);
+            let used = pool.get("used").and_then(Value::as_u64).unwrap_or(0);
+            let total = pool.get("total").and_then(Value::as_u64).unwrap_or(0);
+            let used_fraction = pool
+                .get("used_fraction")
+                .and_then(Value::as_f64)
+                .unwrap_or(0.0);
+            let content = pool.get("content").and_then(Value::as_str).unwrap_or("?");
+
+            lines.push(format!(
+                "{:<20}  {:<10}  {:<10}  {:<12}  {:<12}  {:<8.1}%  {}",
+                name,
+                pool_type,
+                if active == 1 { "active" } else { "inactive" },
+                format_bytes(used),
+                format_bytes(total),
+                used_fraction * 100.0,
+                content,
+            ));
+        }
+
+        Ok(truncate_output(&lines.join("\n"), OUTPUT_MAX_CHARS))
+    }
+    .await;
+
+    match result {
+        Ok(output) => {
+            audit
+                .log("proxmox.storage.list", &host, "success", None)
+                .await
+                .ok();
+            Ok(wrap_output_envelope("proxmox.storage.list", &output))
+        }
+        Err(error) => {
+            audit
+                .log(
+                    "proxmox.storage.list",
+                    &host,
+                    "error",
+                    Some(&error.to_string()),
+                )
+                .await
+                .ok();
+            Err(error)
+        }
+    }
+}
+
+pub async fn network_list(
+    manager: Arc<ConnectionManager>,
+    host: Option<String>,
+    node: Option<String>,
+    audit: Arc<AuditLogger>,
+) -> Result<String> {
+    let host = host.unwrap_or_else(|| default_proxmox_host(&manager));
+    let result: Result<String> = async {
+        let client = manager.get_proxmox(&host)?;
+        let node_name = client.resolve_node(node.as_deref()).await?;
+        let networks = client.get(&format!("/nodes/{}/network", node_name)).await?;
+
+        let networks = networks
+            .as_array()
+            .ok_or_else(|| anyhow!("Unexpected response format from network list"))?;
+
+        if networks.is_empty() {
+            return Ok(format!("No network interfaces found on node '{}'.", node_name));
+        }
+
+        let mut lines = vec![format!(
+            "Network interfaces on node '{}' (Proxmox host: {})\n\n{:<16}  {:<10}  {:<18}  {:<10}  {:<8}  {}",
+            node_name, host, "IFACE", "TYPE", "ADDRESS", "ACTIVE", "AUTO", "BRIDGE PORTS"
+        )];
+
+        for iface in networks {
+            let name = iface.get("iface").and_then(Value::as_str).unwrap_or("?");
+            let iface_type = iface.get("type").and_then(Value::as_str).unwrap_or("?");
+            let address = iface.get("address").and_then(Value::as_str).unwrap_or("-");
+            let cidr = iface.get("cidr").and_then(Value::as_str);
+            let active = iface.get("active").and_then(Value::as_u64).unwrap_or(0);
+            let autostart = iface.get("autostart").and_then(Value::as_u64).unwrap_or(0);
+            let bridge_ports = iface
+                .get("bridge_ports")
+                .and_then(Value::as_str)
+                .unwrap_or("-");
+
+            lines.push(format!(
+                "{:<16}  {:<10}  {:<18}  {:<10}  {:<8}  {}",
+                name,
+                iface_type,
+                cidr.unwrap_or(address),
+                if active == 1 { "yes" } else { "no" },
+                if autostart == 1 { "yes" } else { "no" },
+                bridge_ports,
+            ));
+        }
+
+        Ok(truncate_output(&lines.join("\n"), OUTPUT_MAX_CHARS))
+    }
+    .await;
+
+    match result {
+        Ok(output) => {
+            audit
+                .log("proxmox.network.list", &host, "success", None)
+                .await
+                .ok();
+            Ok(wrap_output_envelope("proxmox.network.list", &output))
+        }
+        Err(error) => {
+            audit
+                .log(
+                    "proxmox.network.list",
+                    &host,
+                    "error",
+                    Some(&error.to_string()),
+                )
+                .await
+                .ok();
+            Err(error)
+        }
+    }
+}
+
+fn default_proxmox_host(manager: &ConnectionManager) -> String {
+    manager
+        .config()
+        .proxmox
+        .hosts
+        .keys()
+        .next()
+        .cloned()
+        .unwrap_or_else(|| "default".to_string())
+}
+
+fn ensure_vm_type(vm_type: &str) -> Result<()> {
+    match vm_type {
+        "qemu" | "lxc" => Ok(()),
+        other => Err(anyhow!("vm_type must be 'qemu' or 'lxc'. Got '{}'", other)),
+    }
+}
+
+fn resolved_vm_type(vm_type: Option<&str>) -> Result<&str> {
+    let vm_type = vm_type.unwrap_or("qemu");
+    ensure_vm_type(vm_type)?;
+    Ok(vm_type)
+}
+
+async fn next_vmid(client: &ProxmoxClient) -> Result<u64> {
+    let next = client.get("/cluster/nextid").await?;
+    next.as_str()
+        .and_then(|value| value.parse::<u64>().ok())
+        .or_else(|| next.as_u64())
+        .ok_or_else(|| anyhow!("Failed to get next available VMID"))
+}
+
+fn bool_to_proxmox(value: bool) -> &'static str {
+    if value { "1" } else { "0" }
+}
+
+fn percent(used: u64, total: u64) -> f64 {
+    if total > 0 {
+        (used as f64 / total as f64) * 100.0
+    } else {
+        0.0
+    }
+}
+
+fn format_loadavg(loadavg: Option<&Value>) -> String {
+    match loadavg.and_then(Value::as_array) {
+        Some(values) if !values.is_empty() => values
+            .iter()
+            .map(|value| match value {
+                Value::String(value) => value.clone(),
+                Value::Number(value) => value.to_string(),
+                _ => "?".to_string(),
+            })
+            .collect::<Vec<_>>()
+            .join(", "),
+        _ => "?".to_string(),
+    }
+}
+
+fn truncate_cell(value: &str, max_chars: usize) -> String {
+    let char_count = value.chars().count();
+    if char_count <= max_chars {
+        return value.to_string();
+    }
+
+    value.chars().take(max_chars).collect()
+}
+
+fn format_uptime(seconds: u64) -> String {
+    let days = seconds / 86_400;
+    let hours = (seconds % 86_400) / 3_600;
+    let minutes = (seconds % 3_600) / 60;
+
+    if days > 0 {
+        format!("{}d {}h {}m", days, hours, minutes)
+    } else if hours > 0 {
+        format!("{}h {}m", hours, minutes)
+    } else {
+        format!("{}m", minutes)
+    }
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = 1024 * KB;
+    const GB: u64 = 1024 * MB;
+    const TB: u64 = 1024 * GB;
+
+    if bytes >= TB {
+        format!("{:.1} TB", bytes as f64 / TB as f64)
+    } else if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} B", bytes)
+    }
+}

--- a/src/tools/verify.rs
+++ b/src/tools/verify.rs
@@ -278,6 +278,7 @@ mod tests {
         let config = Config {
             docker: Default::default(),
             ssh: Default::default(),
+            proxmox: Default::default(),
             audit: crate::config::AuditConfig {
                 file: None,
                 syslog: None,
@@ -298,6 +299,7 @@ mod tests {
         let config = Config {
             docker: Default::default(),
             ssh: Default::default(),
+            proxmox: Default::default(),
             audit: crate::config::AuditConfig {
                 file: Some("/tmp/nonexistent-audit-test-12345.log".into()),
                 syslog: None,
@@ -333,6 +335,7 @@ mod tests {
         let config = Config {
             docker: Default::default(),
             ssh: Default::default(),
+            proxmox: Default::default(),
             audit: crate::config::AuditConfig {
                 file: Some(tmp.path().to_path_buf()),
                 syslog: None,
@@ -372,6 +375,7 @@ mod tests {
         let config = Config {
             docker: Default::default(),
             ssh: Default::default(),
+            proxmox: Default::default(),
             audit: crate::config::AuditConfig {
                 file: Some(tmp.path().to_path_buf()),
                 syslog: None,
@@ -415,6 +419,7 @@ mod tests {
         let config = Config {
             docker: Default::default(),
             ssh: Default::default(),
+            proxmox: Default::default(),
             audit: crate::config::AuditConfig {
                 file: Some(tmp.path().to_path_buf()),
                 syslog: None,
@@ -521,6 +526,7 @@ mod tests {
         let config = Config {
             docker: Default::default(),
             ssh: Default::default(),
+            proxmox: Default::default(),
             audit: crate::config::AuditConfig {
                 file: Some(tmp.path().to_path_buf()),
                 syslog: None,
@@ -561,6 +567,7 @@ mod tests {
         let config = Config {
             docker: Default::default(),
             ssh: Default::default(),
+            proxmox: Default::default(),
             audit: crate::config::AuditConfig {
                 file: Some(tmp.path().to_path_buf()),
                 syslog: None,


### PR DESCRIPTION
## Summary

- Add `ProxmoxConfig`/`ProxmoxHost` to config with API token auth and optional TLS verification (default off for homelab self-signed certs)
- Implement `src/tools/proxmox.rs` with node list/status, VM/CT list, status, start, and stop via the Proxmox REST API (`reqwest` + `rustls`)
- Register all Proxmox tools in `mcp.rs` and expose `proxmox` module in `tools/mod.rs`
- Add `[proxmox]` section to `example.config.toml`
- Add `skills/proxmox-admin` skill with reference docs covering VM lifecycle, snapshot management, storage planning, network configuration, and API troubleshooting
- Add `SPACEBOT-UI-CONFIRMATION-INTEGRATION.md` design doc
- Update README with Proxmox setup instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proxmox VE support: manage hosts, nodes, VMs/containers, snapshots, storage, and networking via 14 MCP tools with dry-run and two-step confirmation, token-based host config, health checks, and Prometheus health metrics

* **Documentation**
  * Extensive Proxmox docs, troubleshooting, network/storage/snapshot guides, README updates, example config, and UI confirmation integration guide

* **Tests**
  * Test scaffolding updated to include default Proxmox configuration fields
<!-- end of auto-generated comment: release notes by coderabbit.ai -->